### PR TITLE
Added spacemouse pro wireless bluetooth edition

### DIFF
--- a/pyspacemouse/pyspacemouse.py
+++ b/pyspacemouse/pyspacemouse.py
@@ -538,6 +538,39 @@ device_specs = {
         ],
         axis_scale=350.0,
     ),
+    "SpaceMouse Pro Wireless Bluetooth": DeviceSpec(
+        name="SpaceMouse Pro Wireless Bluetooth",
+        # vendor ID and product ID
+        hid_id=[0x256F, 0xC638],
+        # LED HID usage code pair
+        led_id=[0x8, 0x4B],
+        mappings={
+            "x": AxisSpec(channel=1, byte1=1, byte2=2, scale=1),
+            "y": AxisSpec(channel=1, byte1=3, byte2=4, scale=-1),
+            "z": AxisSpec(channel=1, byte1=5, byte2=6, scale=-1),
+            "pitch": AxisSpec(channel=1, byte1=7, byte2=8, scale=-1),
+            "roll": AxisSpec(channel=1, byte1=9, byte2=10, scale=-1),
+            "yaw": AxisSpec(channel=1, byte1=11, byte2=12, scale=1),
+        },
+        button_mapping=[
+            ButtonSpec(channel=3, byte=1, bit=0),  # MENU
+            ButtonSpec(channel=3, byte=3, bit=7),  # ALT
+            ButtonSpec(channel=3, byte=4, bit=1),  # CTRL
+            ButtonSpec(channel=3, byte=4, bit=0),  # SHIFT
+            ButtonSpec(channel=3, byte=3, bit=6),  # ESC
+            ButtonSpec(channel=3, byte=2, bit=4),  # 1
+            ButtonSpec(channel=3, byte=2, bit=5),  # 2
+            ButtonSpec(channel=3, byte=2, bit=6),  # 3
+            ButtonSpec(channel=3, byte=2, bit=7),  # 4
+            ButtonSpec(channel=3, byte=2, bit=0),  # ROLL CLOCKWISE
+            ButtonSpec(channel=3, byte=1, bit=2),  # TOP
+            ButtonSpec(channel=3, byte=4, bit=2),  # ROTATION
+            ButtonSpec(channel=3, byte=1, bit=5),  # FRONT
+            ButtonSpec(channel=3, byte=1, bit=4),  # REAR
+            ButtonSpec(channel=3, byte=1, bit=1),  # FIT
+        ],
+        axis_scale=350.0,
+    ),
     "SpaceMouse Pro": DeviceSpec(
         name="SpaceMouse Pro",
         # vendor ID and product ID


### PR DESCRIPTION
The spacemouse pro wireless bluetooth edition seems to be missing, i'm not sure if all values are exactly what they are supposed to be but it seems to work.

## Summary by Sourcery

New Features:
- Support for the SpaceMouse Pro Wireless Bluetooth edition has been added.