### PR TITLE
fix docs generation in CI

### DIFF
--- a/.github/workflows/deploy-web.yaml
+++ b/.github/workflows/deploy-web.yaml
@@ -19,8 +19,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - name: Install Hathch
-        run: pip install hatch
+      - name: Install Hatch
+        run: pip install hatch==1.15.1
       - uses: actions/cache@v4
         with:
           key: mkdocs-${{ github.ref }}

--- a/.github/workflows/deploy-web.yaml
+++ b/.github/workflows/deploy-web.yaml
@@ -19,6 +19,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - name: Install Hathch
+        run: pip install hatch
       - uses: actions/cache@v4
         with:
           key: mkdocs-${{ github.ref }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,10 +142,10 @@ with pyspacemouse.open(device_spec=device_spec) as device:
 See [Custom Device Configuration](https://spacemouse.kubaandrysek.cz/mouseApi/#custom-device-configuration) for more details.
 
 ## How to write documentation
-To install the required dependencies, run `pip install pyspacemouse[docs]`.
+To install the required dependencies, run `make install-dev`, and please also install `doxygen` manually.
 
 Edit `README.md` only in the root folder. The documentation is automatically generated from `README.md` and `docs/` folder.
-To update documentation from root to `/docs` use macro `make fixRelativeLinkDocs` which will replace all relative links from `/` to `/docs` folder.
+To update documentation from root to `/docs`, use `make docs-build`.
 
 ### Building the documentation
 The documentation is built using [mkdocs](https://www.mkdocs.org/). To test the documentation locally, run `make docs-serve` and open [http://localhost:8000](http://localhost:8000) in your browser.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -142,10 +142,10 @@ with pyspacemouse.open(device_spec=device_spec) as device:
 See [Custom Device Configuration](https://spacemouse.kubaandrysek.cz/mouseApi/#custom-device-configuration) for more details.
 
 ## How to write documentation
-To install the required dependencies, run `pip install pyspacemouse[docs]`.
+To install the required dependencies, run `make install-dev`, and please also install `doxygen` manually.
 
 Edit `README.md` only in the root folder. The documentation is automatically generated from `README.md` and `docs/` folder.
-To update documentation from root to `/docs` use macro `make fixRelativeLinkDocs` which will replace all relative links from `/` to `/docs` folder.
+To update documentation from root to `/docs`, use `make docs-build`.
 
 ### Building the documentation
 The documentation is built using [mkdocs](https://www.mkdocs.org/). To test the documentation locally, run `make docs-serve` and open [http://localhost:8000](http://localhost:8000) in your browser.

--- a/docs/README.md
+++ b/docs/README.md
@@ -231,6 +231,8 @@ pipx install hatch==1.15.1 pre-commit
 
 If you're not familiar with pipx, it lets you install python tools into isolated environments in `~/.local`.
 
+For building the documentation locally, you will also need `doxygen` installed and on the path.
+
 ## Used In
 
 - [TeleMoMa](https://github.com/UT-Austin-RobIn/telemoma) - A Modular and Versatile Teleoperation System for Mobile Manipulation


### PR DESCRIPTION
## Summary by Sourcery

Update documentation contribution instructions and fix documentation build requirements in CI.

CI:
- Install Hatch in the documentation deployment workflow to satisfy docs build tooling requirements.

Documentation:
- Clarify documentation setup to use `make install-dev`, require manual `doxygen` installation, and refer to `make docs-build` for syncing docs.