### PR TITLE
Add `get_connected_devices_by_path` API to more clearly handle multiple devices of different types

### DIFF
--- a/.github/instructions/review.instructions.md
+++ b/.github/instructions/review.instructions.md
@@ -1,0 +1,4 @@
+Focus on backwards compatibility and user experience.
+Point out any API changes.
+Keep your responses very short.
+Do not summarize the changes.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ pip install pyspacemouse
 
 ## Quick Start
 
+Here we use `has_motion()` to check if any of the spatial axes have non-zero values.
+The optional argument is the threshold used, and is applied per-axis.
+
 ```python
 import pyspacemouse
 
@@ -49,7 +52,7 @@ import pyspacemouse
 with pyspacemouse.open() as device:
     while True:
         state = device.read()
-        if state.nonzero(0.01):
+        if state.has_motion(0.01):
             print(state.x, state.y, state.z, state.roll, state.pitch, state.yaw)
 ```
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ import pyspacemouse
 pyspacemouse.get_connected_devices()
 # Returns: ["SpaceNavigator", "SpaceMouse Pro", ...]
 
+# List connected SpaceMouse devices with paths
+pyspacemouse.get_connected_paths_and_names()
+# Returns: [("/dev/hidraw0", "SpaceNavigator"), ...]
+
 # List all supported device types
 pyspacemouse.get_supported_devices()
 # Returns: [(name, vendor_id, product_id), ...]

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ import pyspacemouse
 with pyspacemouse.open() as device:
     while True:
         state = device.read()
-        print(state.x, state.y, state.z)
+        if state.nonzero(0.01):
+            print(state.x, state.y, state.z, state.roll, state.pitch, state.yaw)
 ```
 
 ## API Reference
@@ -145,6 +146,7 @@ with pyspacemouse.open(
 ) as device:
     while True:
         device.read()  # Triggers callbacks
+        time.sleep(0.001) # NOTE: avoid larger sleeps, which can cause data to buffer
 ```
 
 ### Custom Axis Mapping

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ pyspacemouse.get_connected_devices()
 # Returns: ["SpaceNavigator", "SpaceMouse Pro", ...]
 
 # List connected SpaceMouse devices with paths
-pyspacemouse.get_connected_paths_and_names()
+pyspacemouse.get_connected_devices_by_path()
 # Returns: [("/dev/hidraw0", "SpaceNavigator"), ...]
 
 # List all supported device types

--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ with pyspacemouse.open() as device:
 ### Callbacks
 
 ```python
+import pyspacemouse
+import time
+
 # Button callback
 def on_button(state, buttons, pressed):
     print(f"Button {pressed} pressed!")

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ pyspacemouse.get_connected_devices()
 
 # List connected SpaceMouse devices with paths
 pyspacemouse.get_connected_devices_by_path()
-# Returns: [("/dev/hidraw0", "SpaceNavigator"), ...]
+# Returns: {"/dev/hidraw0": "SpaceNavigator", ...}
 
 # List all supported device types
 pyspacemouse.get_supported_devices()

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,6 +42,9 @@ pip install pyspacemouse
 
 ## Quick Start
 
+Here we use `has_motion()` to check if any of the spatial axes have non-zero values.
+The optional argument is the threshold used, and is applied per-axis.
+
 ```python
 import pyspacemouse
 
@@ -49,7 +52,7 @@ import pyspacemouse
 with pyspacemouse.open() as device:
     while True:
         state = device.read()
-        if state.nonzero(0.01):
+        if state.has_motion(0.01):
             print(state.x, state.y, state.z, state.roll, state.pitch, state.yaw)
 ```
 
@@ -68,7 +71,7 @@ pyspacemouse.get_connected_devices()
 # Returns: ["SpaceNavigator", "SpaceMouse Pro", ...]
 
 # List connected SpaceMouse devices with paths
-pyspacemouse.get_connected_devices_by_path()
+pyspacemouse.get_connected_paths_and_names()
 # Returns: [("/dev/hidraw0", "SpaceNavigator"), ...]
 
 # List all supported device types

--- a/docs/README.md
+++ b/docs/README.md
@@ -66,6 +66,10 @@ import pyspacemouse
 pyspacemouse.get_connected_devices()
 # Returns: ["SpaceNavigator", "SpaceMouse Pro", ...]
 
+# List connected SpaceMouse devices with paths
+pyspacemouse.get_connected_paths_and_names()
+# Returns: [("/dev/hidraw0", "SpaceNavigator"), ...]
+
 # List all supported device types
 pyspacemouse.get_supported_devices()
 # Returns: [(name, vendor_id, product_id), ...]

--- a/docs/README.md
+++ b/docs/README.md
@@ -71,7 +71,7 @@ pyspacemouse.get_connected_devices()
 # Returns: ["SpaceNavigator", "SpaceMouse Pro", ...]
 
 # List connected SpaceMouse devices with paths
-pyspacemouse.get_connected_paths_and_names()
+pyspacemouse.get_connected_devices_by_path()
 # Returns: [("/dev/hidraw0", "SpaceNavigator"), ...]
 
 # List all supported device types

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,7 +49,8 @@ import pyspacemouse
 with pyspacemouse.open() as device:
     while True:
         state = device.read()
-        print(state.x, state.y, state.z)
+        if state.nonzero(0.01):
+            print(state.x, state.y, state.z, state.roll, state.pitch, state.yaw)
 ```
 
 ## API Reference
@@ -67,7 +68,7 @@ pyspacemouse.get_connected_devices()
 # Returns: ["SpaceNavigator", "SpaceMouse Pro", ...]
 
 # List connected SpaceMouse devices with paths
-pyspacemouse.get_connected_paths_and_names()
+pyspacemouse.get_connected_devices_by_path()
 # Returns: [("/dev/hidraw0", "SpaceNavigator"), ...]
 
 # List all supported device types
@@ -119,6 +120,9 @@ with pyspacemouse.open() as device:
 ### Callbacks
 
 ```python
+import pyspacemouse
+import time
+
 # Button callback
 def on_button(state, buttons, pressed):
     print(f"Button {pressed} pressed!")
@@ -145,6 +149,7 @@ with pyspacemouse.open(
 ) as device:
     while True:
         device.read()  # Triggers callbacks
+        time.sleep(0.001) # NOTE: avoid larger sleeps, which can cause data to buffer
 ```
 
 ### Custom Axis Mapping

--- a/docs/README.md
+++ b/docs/README.md
@@ -72,7 +72,7 @@ pyspacemouse.get_connected_devices()
 
 # List connected SpaceMouse devices with paths
 pyspacemouse.get_connected_devices_by_path()
-# Returns: [("/dev/hidraw0", "SpaceNavigator"), ...]
+# Returns: {"/dev/hidraw0": "SpaceNavigator", ...}
 
 # List all supported device types
 pyspacemouse.get_supported_devices()

--- a/examples/01_basic.py
+++ b/examples/01_basic.py
@@ -4,8 +4,6 @@ This is the simplest way to use PySpaceMouse. The context manager
 ensures the device is properly closed when you're done.
 """
 
-import time
-
 import pyspacemouse
 
 # Using context manager (recommended)
@@ -16,12 +14,8 @@ with pyspacemouse.open() as device:
     while True:
         state = device.read()
 
-        if any(
-            abs(val) > 0.01
-            for val in [state.x, state.y, state.z, state.roll, state.pitch, state.yaw]
-        ):
+        if state.nonzero():
             print(
                 f"x={state.x:+.2f} y={state.y:+.2f} z={state.z:+.2f} "
                 f"roll={state.roll:+.2f} pitch={state.pitch:+.2f} yaw={state.yaw:+.2f}"
             )
-        time.sleep(0.01)

--- a/examples/01_basic.py
+++ b/examples/01_basic.py
@@ -14,7 +14,7 @@ with pyspacemouse.open() as device:
     while True:
         state = device.read()
 
-        if state.nonzero():
+        if state.has_motion():
             print(
                 f"x={state.x:+.2f} y={state.y:+.2f} z={state.z:+.2f} "
                 f"roll={state.roll:+.2f} pitch={state.pitch:+.2f} yaw={state.yaw:+.2f}"

--- a/examples/02_callbacks.py
+++ b/examples/02_callbacks.py
@@ -49,4 +49,4 @@ with pyspacemouse.open(
 
     while True:
         device.read()  # Must call read() to process callbacks
-        time.sleep(0.01)  # NOTE: large sleeps can cause data to buffer
+        time.sleep(0.01)

--- a/examples/02_callbacks.py
+++ b/examples/02_callbacks.py
@@ -49,4 +49,4 @@ with pyspacemouse.open(
 
     while True:
         device.read()  # Must call read() to process callbacks
-        time.sleep(0.01)
+        time.sleep(0.01)  # NOTE: large sleeps can cause data to buffer

--- a/examples/03_multi_device.py
+++ b/examples/03_multi_device.py
@@ -11,20 +11,19 @@ import pyspacemouse
 
 def main():
     # First, discover connected devices
-    connected = pyspacemouse.get_connected_devices()
-    print(f"Found {len(connected)} device(s): {connected}")
+    devices = pyspacemouse.get_connected_spacemice()
+    paths = [path for path, name in devices]
+    names = [name for path, name in devices]
+    print(f"Found {len(names)} spacemouse device(s): {names}")
 
-    if len(connected) < 2:
+    if len(names) < 2:
         print("This example requires 2 SpaceMouse devices connected.")
         print("Tip: Use a 3Dconnexion Universal Receiver with device_index parameter")
         return
 
-    # Open two devices using device_index
-    # device_index=0 is the first device, device_index=1 is the second
-    device_name = connected[0]
-
-    with pyspacemouse.open(device=device_name, device_index=0) as left_hand:
-        with pyspacemouse.open(device=device_name, device_index=1) as right_hand:
+    # Open two devices by path
+    with pyspacemouse.open_by_path(paths[0]) as left_hand:
+        with pyspacemouse.open_by_path(paths[1]) as right_hand:
             print(f"Left hand:  {left_hand.name}")
             print(f"Right hand: {right_hand.name}")
             print()
@@ -35,8 +34,8 @@ def main():
                 right = right_hand.read()
 
                 print(
-                    f"L: x={left.x:+.2f} y={left.y:+.2f} z={left.z:+.2f}  |  "
-                    f"R: x={right.x:+.2f} y={right.y:+.2f} z={right.z:+.2f}"
+                    f"Left: x={left.x:+.2f} y={left.y:+.2f} z={left.z:+.2f}  |  "
+                    f"Right: x={right.x:+.2f} y={right.y:+.2f} z={right.z:+.2f}"
                 )
                 time.sleep(0.02)
 

--- a/examples/03_multi_device.py
+++ b/examples/03_multi_device.py
@@ -11,7 +11,7 @@ import pyspacemouse
 
 def main():
     # First, discover connected devices
-    devices = pyspacemouse.get_connected_spacemice()
+    devices = pyspacemouse.get_connected_devices()
     paths = [path for path, name in devices]
     names = [name for path, name in devices]
     print(f"Found {len(names)} spacemouse device(s): {names}")

--- a/examples/03_multi_device.py
+++ b/examples/03_multi_device.py
@@ -11,9 +11,7 @@ import pyspacemouse
 
 def main():
     # First, discover connected devices
-    devices = pyspacemouse.get_connected_devices()
-    paths = [path for path, name in devices]
-    names = [name for path, name in devices]
+    paths, names = pyspacemouse.get_connected_paths_and_names()
     print(f"Found {len(names)} spacemouse device(s): {names}")
 
     if len(names) < 2:

--- a/examples/03_multi_device.py
+++ b/examples/03_multi_device.py
@@ -4,24 +4,26 @@ This example shows how to open two SpaceMouse devices simultaneously,
 useful for dual-hand control or controlling multiple robots.
 """
 
-import time
-
 import pyspacemouse
 
 
 def main():
     # First, discover connected devices
-    paths, names = pyspacemouse.get_connected_paths_and_names()
-    print(f"Found {len(names)} spacemouse device(s): {names}")
+    connected = pyspacemouse.get_connected_paths_and_names()
+    print(f"Found {len(connected)} spacemouse device(s): {list(connected.values())}")
 
-    if len(names) < 2:
+    if len(connected) < 2:
         print("This example requires 2 SpaceMouse devices connected.")
         print("Tip: Use a 3Dconnexion Universal Receiver with device_index parameter")
         return
 
+    # Arbitrarily take the first two devices found
+    path0 = list(connected.keys())[0]
+    path1 = list(connected.keys())[1]
+
     # Open two devices by path
-    with pyspacemouse.open_by_path(paths[0]) as left_hand:
-        with pyspacemouse.open_by_path(paths[1]) as right_hand:
+    with pyspacemouse.open_by_path(path0) as left_hand:
+        with pyspacemouse.open_by_path(path1) as right_hand:
             print(f"Left hand:  {left_hand.name}")
             print(f"Right hand: {right_hand.name}")
             print()
@@ -31,11 +33,11 @@ def main():
                 left = left_hand.read()
                 right = right_hand.read()
 
-                print(
-                    f"Left: x={left.x:+.2f} y={left.y:+.2f} z={left.z:+.2f}  |  "
-                    f"Right: x={right.x:+.2f} y={right.y:+.2f} z={right.z:+.2f}"
-                )
-                time.sleep(0.02)
+                if left.nonzero() or right.nonzero():
+                    print(
+                        f"Left: x={left.x:+.2f} y={left.y:+.2f} z={left.z:+.2f}  |  "
+                        f"Right: x={right.x:+.2f} y={right.y:+.2f} z={right.z:+.2f}"
+                    )
 
 
 if __name__ == "__main__":

--- a/examples/03_multi_device.py
+++ b/examples/03_multi_device.py
@@ -35,7 +35,7 @@ def main():
                 left = left_hand.read()
                 right = right_hand.read()
 
-                if left.nonzero() or right.nonzero():
+                if left.has_motion() or right.has_motion():
                     print(
                         f"Left: x={left.x:+.2f} y={left.y:+.2f} z={left.z:+.2f}  |  "
                         f"Right: x={right.x:+.2f} y={right.y:+.2f} z={right.z:+.2f}"

--- a/examples/03_multi_device.py
+++ b/examples/03_multi_device.py
@@ -11,7 +11,7 @@ import pyspacemouse
 
 def main():
     # First, discover connected devices
-    connected = pyspacemouse.get_connected_paths_and_names()
+    connected = pyspacemouse.get_connected_devices_by_path()
     print(f"Found {len(connected)} spacemouse device(s): {list(connected.values())}")
 
     if len(connected) < 2:

--- a/examples/03_multi_device.py
+++ b/examples/03_multi_device.py
@@ -4,6 +4,8 @@ This example shows how to open two SpaceMouse devices simultaneously,
 useful for dual-hand control or controlling multiple robots.
 """
 
+import time
+
 import pyspacemouse
 
 
@@ -38,6 +40,8 @@ def main():
                         f"Left: x={left.x:+.2f} y={left.y:+.2f} z={left.z:+.2f}  |  "
                         f"Right: x={right.x:+.2f} y={right.y:+.2f} z={right.z:+.2f}"
                     )
+
+                time.sleep(0.01)
 
 
 if __name__ == "__main__":

--- a/examples/04_open_by_path.py
+++ b/examples/04_open_by_path.py
@@ -9,8 +9,6 @@ Note: Device paths vary by OS:
 - Windows: Uses different path format
 """
 
-import time
-
 import pyspacemouse
 
 
@@ -34,8 +32,11 @@ def main():
 
             while True:
                 state = device.read()
-                print(f"x={state.x:+.2f} y={state.y:+.2f} z={state.z:+.2f}")
-                time.sleep(0.01)
+                if state.nonzero():
+                    print(
+                        f"x={state.x:+.2f} y={state.y:+.2f} z={state.z:+.2f} "
+                        f"r={state.roll:+.2f} p={state.pitch:+.2f} y={state.yaw:+.2f}"
+                    )
 
     except FileNotFoundError as e:
         print(f"Device path not found: {e}")

--- a/examples/04_open_by_path.py
+++ b/examples/04_open_by_path.py
@@ -32,7 +32,7 @@ def main():
 
             while True:
                 state = device.read()
-                if state.nonzero():
+                if state.has_motion():
                     print(
                         f"x={state.x:+.2f} y={state.y:+.2f} z={state.z:+.2f} "
                         f"r={state.roll:+.2f} p={state.pitch:+.2f} y={state.yaw:+.2f}"

--- a/examples/05_discovery.py
+++ b/examples/05_discovery.py
@@ -15,7 +15,7 @@ def main():
 
     # 1. List connected SpaceMouse devices
     print("Connected SpaceMouse devices:")
-    connected = pyspacemouse.get_connected_spacemice()
+    connected = pyspacemouse.get_connected_devices()
     connected_names = [name for _, name in connected]
     if connected:
         for name in connected_names:

--- a/examples/05_discovery.py
+++ b/examples/05_discovery.py
@@ -15,9 +15,10 @@ def main():
 
     # 1. List connected SpaceMouse devices
     print("Connected SpaceMouse devices:")
-    connected = pyspacemouse.get_connected_devices()
+    connected = pyspacemouse.get_connected_spacemice()
+    connected_names = [name for _, name in connected]
     if connected:
-        for name in connected:
+        for name in connected_names:
             print(f"  ✓ {name}")
     else:
         print("  (none found)")
@@ -28,7 +29,7 @@ def main():
     supported = pyspacemouse.get_supported_devices()
     for name, vid, pid in supported:
         # Check if this device type is connected
-        is_connected = name in connected
+        is_connected = name in connected_names
         status = "✓" if is_connected else " "
         print(f"  [{status}] {name} (VID: {vid:#06x}, PID: {pid:#06x})")
     print()

--- a/examples/05_discovery.py
+++ b/examples/05_discovery.py
@@ -16,9 +16,8 @@ def main():
     # 1. List connected SpaceMouse devices
     print("Connected SpaceMouse devices:")
     connected = pyspacemouse.get_connected_devices()
-    connected_names = [name for _, name in connected]
     if connected:
-        for name in connected_names:
+        for name in connected:
             print(f"  ✓ {name}")
     else:
         print("  (none found)")
@@ -29,7 +28,7 @@ def main():
     supported = pyspacemouse.get_supported_devices()
     for name, vid, pid in supported:
         # Check if this device type is connected
-        is_connected = name in connected_names
+        is_connected = name in connected
         status = "✓" if is_connected else " "
         print(f"  [{status}] {name} (VID: {vid:#06x}, PID: {pid:#06x})")
     print()

--- a/examples/05_discovery.py
+++ b/examples/05_discovery.py
@@ -15,9 +15,9 @@ def main():
 
     # 1. List connected SpaceMouse devices
     print("Connected SpaceMouse devices:")
-    connected = pyspacemouse.get_connected_devices()
+    connected = pyspacemouse.get_connected_paths_and_names()
     if connected:
-        for name in connected:
+        for name in connected.values():
             print(f"  ✓ {name}")
     else:
         print("  (none found)")
@@ -26,11 +26,17 @@ def main():
     # 2. List all supported device types
     print("Supported device types:")
     supported = pyspacemouse.get_supported_devices()
-    for name, vid, pid in supported:
+    for supported_name, vid, pid in supported:
         # Check if this device type is connected
-        is_connected = name in connected
-        status = "✓" if is_connected else " "
-        print(f"  [{status}] {name} (VID: {vid:#06x}, PID: {pid:#06x})")
+        status = " "
+        path_if_connected = ""
+        for path, name in connected.items():
+            if name == supported_name:
+                status = "✓"
+                path_if_connected = f"   (path: {path})"
+        print(
+            f"  [{status}] {supported_name} (VID: {vid:#06x}, PID: {pid:#06x}){path_if_connected}"
+        )
     print()
 
     # 3. List ALL HID devices (for debugging)

--- a/examples/05_discovery.py
+++ b/examples/05_discovery.py
@@ -15,7 +15,7 @@ def main():
 
     # 1. List connected SpaceMouse devices
     print("Connected SpaceMouse devices:")
-    connected = pyspacemouse.get_connected_paths_and_names()
+    connected = pyspacemouse.get_connected_devices_by_path()
     if connected:
         for name in connected.values():
             print(f"  ✓ {name}")

--- a/examples/09_custom_config.py
+++ b/examples/09_custom_config.py
@@ -36,7 +36,7 @@ def example_modify_existing():
     print(f"Using device: {device_name}")
 
     # Get base spec and create modified version
-    base_spec = specs[device_path]
+    base_spec = specs[device_name]
     print(f"Original mappings: y scale = {base_spec.mappings['y'].scale}")
 
     # Create modified spec with inverted Y and Z (common for ROS)
@@ -53,11 +53,11 @@ def example_modify_existing():
         print("Move the SpaceMouse (Ctrl+C to exit)")
         print("Y and Z axes are now inverted!\n")
 
-        for _ in range(50):  # Run for ~5 seconds
+        for _ in range(500):  # Run for ~5 seconds
             state = device.read()
             if any([state.x, state.y, state.z]):
                 print(f"x={state.x:+.2f} y={state.y:+.2f} z={state.z:+.2f} (Y/Z inverted)")
-            time.sleep(0.1)
+            time.sleep(0.01)
 
 
 def example_invert_rotations():
@@ -90,11 +90,11 @@ def example_invert_rotations():
         print(f"Connected to: {device.name}")
         print("Roll and Yaw are now inverted!\n")
 
-        for _ in range(30):
+        for _ in range(500):
             state = device.read()
             if any([state.roll, state.pitch, state.yaw]):
                 print(f"roll={state.roll:+.2f} pitch={state.pitch:+.2f} yaw={state.yaw:+.2f}")
-            time.sleep(0.1)
+            time.sleep(0.01)
 
 
 def example_create_custom():

--- a/examples/09_custom_config.py
+++ b/examples/09_custom_config.py
@@ -23,16 +23,20 @@ def example_modify_existing():
     print(f"Available devices: {list(specs.keys())}")
 
     # Get connected devices
-    connected = pyspacemouse.get_connected_devices()
+    connected = pyspacemouse.get_connected_spacemice()
     if not connected:
         print("No devices connected!")
         return
+    if len(connected) > 1:
+        print("This example only works with one device connected.")
+        return
 
-    device_name = connected[0]
+    device = connected[0]
+    device_path, device_name = device
     print(f"Using device: {device_name}")
 
     # Get base spec and create modified version
-    base_spec = specs[device_name]
+    base_spec = specs[device_path]
     print(f"Original mappings: y scale = {base_spec.mappings['y'].scale}")
 
     # Create modified spec with inverted Y and Z (common for ROS)
@@ -62,18 +66,23 @@ def example_invert_rotations():
     print("Example 2: Fix rotation conventions")
     print("=" * 60)
 
-    connected = pyspacemouse.get_connected_devices()
+    connected = pyspacemouse.get_connected_spacemice()
     if not connected:
         print("No devices connected!")
         return
+    if len(connected) > 1:
+        print("This example only works with one device connected.")
+        return
 
+    device = connected[0]
+    device_path, device_name = device
     specs = pyspacemouse.get_device_specs()
-    base_spec = specs[connected[0]]
+    base_spec = specs[device_name]
 
     # Invert roll and yaw for right-handed coordinate system
     fixed_spec = pyspacemouse.modify_device_info(
         base_spec,
-        name=f"{connected[0]} (Fixed Rotations)",
+        name=f"{device_name} (Fixed Rotations)",
         invert_axes=["roll", "yaw"],
     )
 

--- a/examples/09_custom_config.py
+++ b/examples/09_custom_config.py
@@ -23,7 +23,7 @@ def example_modify_existing():
     print(f"Available devices: {list(specs.keys())}")
 
     # Get connected devices
-    connected = pyspacemouse.get_connected_spacemice()
+    connected = pyspacemouse.get_connected_devices()
     if not connected:
         print("No devices connected!")
         return
@@ -66,7 +66,7 @@ def example_invert_rotations():
     print("Example 2: Fix rotation conventions")
     print("=" * 60)
 
-    connected = pyspacemouse.get_connected_spacemice()
+    connected = pyspacemouse.get_connected_devices()
     if not connected:
         print("No devices connected!")
         return

--- a/examples/09_custom_config.py
+++ b/examples/09_custom_config.py
@@ -31,8 +31,7 @@ def example_modify_existing():
         print("This example only works with one device connected.")
         return
 
-    device = connected[0]
-    device_path, device_name = device
+    device_name = connected[0]
     print(f"Using device: {device_name}")
 
     # Get base spec and create modified version
@@ -74,8 +73,7 @@ def example_invert_rotations():
         print("This example only works with one device connected.")
         return
 
-    device = connected[0]
-    device_path, device_name = device
+    device_name = connected[0]
     specs = pyspacemouse.get_device_specs()
     base_spec = specs[device_name]
 

--- a/examples/09_custom_config.py
+++ b/examples/09_custom_config.py
@@ -54,7 +54,7 @@ def example_modify_existing():
 
         for _ in range(500):  # Run for ~5 seconds
             state = device.read()
-            if state.nonzero():
+            if state.has_motion():
                 print(f"x={state.x:+.2f} y={state.y:+.2f} z={state.z:+.2f} (Y/Z inverted)")
             time.sleep(0.01)
 
@@ -90,7 +90,7 @@ def example_invert_rotations():
 
         for _ in range(500):
             state = device.read()
-            if state.nonzero():
+            if state.has_motion():
                 print(f"roll={state.roll:+.2f} pitch={state.pitch:+.2f} yaw={state.yaw:+.2f}")
             time.sleep(0.01)
 

--- a/examples/09_custom_config.py
+++ b/examples/09_custom_config.py
@@ -23,7 +23,7 @@ def example_modify_existing():
     print(f"Available devices: {list(specs.keys())}")
 
     # Get connected devices
-    connected = pyspacemouse.get_connected_devices()
+    connected = pyspacemouse.get_connected_paths_and_names()
     if not connected:
         print("No devices connected!")
         return
@@ -31,7 +31,7 @@ def example_modify_existing():
         print("This example only works with one device connected.")
         return
 
-    device_name = connected[0]
+    device_name = list(connected.values())[0]
     print(f"Using device: {device_name}")
 
     # Get base spec and create modified version
@@ -54,7 +54,7 @@ def example_modify_existing():
 
         for _ in range(500):  # Run for ~5 seconds
             state = device.read()
-            if any([state.x, state.y, state.z]):
+            if state.nonzero():
                 print(f"x={state.x:+.2f} y={state.y:+.2f} z={state.z:+.2f} (Y/Z inverted)")
             time.sleep(0.01)
 
@@ -65,7 +65,7 @@ def example_invert_rotations():
     print("Example 2: Fix rotation conventions")
     print("=" * 60)
 
-    connected = pyspacemouse.get_connected_devices()
+    connected = pyspacemouse.get_connected_paths_and_names()
     if not connected:
         print("No devices connected!")
         return
@@ -73,7 +73,7 @@ def example_invert_rotations():
         print("This example only works with one device connected.")
         return
 
-    device_name = connected[0]
+    device_name = list(connected.values())[0]
     specs = pyspacemouse.get_device_specs()
     base_spec = specs[device_name]
 
@@ -90,7 +90,7 @@ def example_invert_rotations():
 
         for _ in range(500):
             state = device.read()
-            if any([state.roll, state.pitch, state.yaw]):
+            if state.nonzero():
                 print(f"roll={state.roll:+.2f} pitch={state.pitch:+.2f} yaw={state.yaw:+.2f}")
             time.sleep(0.01)
 

--- a/examples/09_custom_config.py
+++ b/examples/09_custom_config.py
@@ -23,7 +23,7 @@ def example_modify_existing():
     print(f"Available devices: {list(specs.keys())}")
 
     # Get connected devices
-    connected = pyspacemouse.get_connected_paths_and_names()
+    connected = pyspacemouse.get_connected_devices_by_path()
     if not connected:
         print("No devices connected!")
         return
@@ -65,7 +65,7 @@ def example_invert_rotations():
     print("Example 2: Fix rotation conventions")
     print("=" * 60)
 
-    connected = pyspacemouse.get_connected_paths_and_names()
+    connected = pyspacemouse.get_connected_devices_by_path()
     if not connected:
         print("No devices connected!")
         return

--- a/pyspacemouse/__init__.py
+++ b/pyspacemouse/__init__.py
@@ -37,7 +37,7 @@ except PackageNotFoundError:
 # Public API
 from .api import (
     get_all_hid_devices,
-    get_connected_spacemice,
+    get_connected_devices,
     get_supported_devices,
     open,
     open_by_path,
@@ -95,7 +95,7 @@ __all__ = [
     "SpaceMouseDevice",
     # API
     "get_all_hid_devices",
-    "get_connected_spacemice",
+    "get_connected_devices",
     "get_supported_devices",
     "open",
     "open_by_path",

--- a/pyspacemouse/__init__.py
+++ b/pyspacemouse/__init__.py
@@ -37,7 +37,7 @@ except PackageNotFoundError:
 # Public API
 from .api import (
     get_all_hid_devices,
-    get_connected_devices,
+    get_connected_spacemice,
     get_supported_devices,
     open,
     open_by_path,
@@ -95,7 +95,7 @@ __all__ = [
     "SpaceMouseDevice",
     # API
     "get_all_hid_devices",
-    "get_connected_devices",
+    "get_connected_spacemice",
     "get_supported_devices",
     "open",
     "open_by_path",

--- a/pyspacemouse/__init__.py
+++ b/pyspacemouse/__init__.py
@@ -38,7 +38,7 @@ except PackageNotFoundError:
 from .api import (
     get_all_hid_devices,
     get_connected_devices,
-    get_connected_paths_and_names,
+    get_connected_devices_by_path,
     get_supported_devices,
     open,
     open_by_path,
@@ -97,7 +97,7 @@ __all__ = [
     # API
     "get_all_hid_devices",
     "get_connected_devices",
-    "get_connected_paths_and_names",
+    "get_connected_devices_by_path",
     "get_supported_devices",
     "open",
     "open_by_path",

--- a/pyspacemouse/__init__.py
+++ b/pyspacemouse/__init__.py
@@ -38,6 +38,7 @@ except PackageNotFoundError:
 from .api import (
     get_all_hid_devices,
     get_connected_devices,
+    get_connected_paths_and_names,
     get_supported_devices,
     open,
     open_by_path,
@@ -96,6 +97,7 @@ __all__ = [
     # API
     "get_all_hid_devices",
     "get_connected_devices",
+    "get_connected_paths_and_names",
     "get_supported_devices",
     "open",
     "open_by_path",

--- a/pyspacemouse/api.py
+++ b/pyspacemouse/api.py
@@ -31,7 +31,7 @@ def get_connected_devices() -> List[Tuple[str, str]]:
     """Return the paths and names of the supported devices currently connected.
 
     Returns:
-        Tuple of two lists: (device_paths, device_names)
+        List of tuples: (device_path, device_name).
         Empty list if no supported devices are found.
 
     Raises:

--- a/pyspacemouse/api.py
+++ b/pyspacemouse/api.py
@@ -27,11 +27,11 @@ from .loader import get_device_specs
 from .types import DeviceInfo, SpaceMouseState
 
 
-def get_connected_devices() -> List[str]:
-    """Return a list of the supported devices currently connected.
+def get_connected_spacemice() -> List[Tuple[str, str]]:
+    """Return the paths and names of the supported devices currently connected.
 
     Returns:
-        List of device names that are both supported and connected.
+        Tuple of two lists: (device_paths, device_names)
         Empty list if no supported devices are found.
 
     Raises:
@@ -45,14 +45,14 @@ def get_connected_devices() -> List[str]:
         ) from e
 
     device_specs = get_device_specs()
-    devices = []
+    devices_by_path = {}
 
     for hid_device in hid.find():
         for name, spec in device_specs.items():
             if hid_device.vendor_id == spec.vendor_id and hid_device.product_id == spec.product_id:
-                devices.append(name)
+                devices_by_path[hid_device.path] = name
 
-    return devices
+    return list(devices_by_path.items())
 
 
 def get_supported_devices() -> List[Tuple[str, int, int]]:
@@ -253,10 +253,10 @@ def open(
 
     # Auto-detect device if not specified
     if device is None:
-        connected = get_connected_devices()
+        connected = get_connected_spacemice()
         if not connected:
             raise RuntimeError("No connected or supported devices found.")
-        device = connected[0]
+        device = connected[0][1]
 
     if device not in device_specs:
         raise ValueError(f"Unknown device: '{device}'. Available: {list(device_specs.keys())}")

--- a/pyspacemouse/api.py
+++ b/pyspacemouse/api.py
@@ -27,7 +27,7 @@ from .loader import get_device_specs
 from .types import DeviceInfo, SpaceMouseState
 
 
-def get_connected_spacemice() -> List[Tuple[str, str]]:
+def get_connected_devices() -> List[Tuple[str, str]]:
     """Return the paths and names of the supported devices currently connected.
 
     Returns:
@@ -253,7 +253,7 @@ def open(
 
     # Auto-detect device if not specified
     if device is None:
-        connected = get_connected_spacemice()
+        connected = get_connected_devices()
         if not connected:
             raise RuntimeError("No connected or supported devices found.")
         device = connected[0][1]

--- a/pyspacemouse/api.py
+++ b/pyspacemouse/api.py
@@ -323,7 +323,7 @@ def open_with_config(
     )
 
 
-def get_connected_paths_and_names() -> Dict[str, str]:
+def get_connected_devices_by_path() -> Dict[str, str]:
     """Return the paths and names of the supported devices currently connected.
 
     Returns:

--- a/pyspacemouse/api.py
+++ b/pyspacemouse/api.py
@@ -17,7 +17,7 @@ Usage:
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Callable, List, Optional, Sequence, Tuple
+from typing import Callable, Dict, List, Optional, Sequence, Tuple
 
 from easyhid import Enumeration
 
@@ -256,7 +256,7 @@ def open(
         connected = get_connected_devices()
         if not connected:
             raise RuntimeError("No connected or supported devices found.")
-        device = connected[0][1]
+        device = connected[0]
 
     if device not in device_specs:
         raise ValueError(f"Unknown device: '{device}'. Available: {list(device_specs.keys())}")
@@ -323,12 +323,11 @@ def open_with_config(
     )
 
 
-def get_connected_paths_and_names() -> Tuple[List[str], List[str]]:
+def get_connected_paths_and_names() -> Dict[str, str]:
     """Return the paths and names of the supported devices currently connected.
 
     Returns:
-        Tuple of two lists: (device_paths, device_names).
-        Tuple of empty lists if no supported devices are found.
+        Dict of paths: device names (e.g., {"/dev/hidraw0": "SpaceMouse Pro"}).
 
     Raises:
         RuntimeError: If HID API is not installed.
@@ -341,15 +340,13 @@ def get_connected_paths_and_names() -> Tuple[List[str], List[str]]:
         ) from e
 
     device_specs = get_device_specs()
-    device_paths = []
-    device_names = []
+    devices_by_path = {}
 
     # hid.find() is all connected HID devices,
     # device_specs is all supported Spacemouse devices.
     for hid_device in hid.find():
         for name, spec in device_specs.items():
             if hid_device.vendor_id == spec.vendor_id and hid_device.product_id == spec.product_id:
-                device_paths.append(hid_device.path)
-                device_names.append(name)
+                devices_by_path[hid_device.path] = name
 
-    return device_paths, device_names
+    return devices_by_path

--- a/pyspacemouse/api.py
+++ b/pyspacemouse/api.py
@@ -27,11 +27,11 @@ from .loader import get_device_specs
 from .types import DeviceInfo, SpaceMouseState
 
 
-def get_connected_devices() -> List[Tuple[str, str]]:
-    """Return the paths and names of the supported devices currently connected.
+def get_connected_devices() -> List[str]:
+    """Return a list of the supported devices currently connected.
 
     Returns:
-        List of tuples: (device_path, device_name).
+        List of device names that are both supported and connected.
         Empty list if no supported devices are found.
 
     Raises:
@@ -45,14 +45,14 @@ def get_connected_devices() -> List[Tuple[str, str]]:
         ) from e
 
     device_specs = get_device_specs()
-    devices_by_path = {}
+    devices = []
 
     for hid_device in hid.find():
         for name, spec in device_specs.items():
             if hid_device.vendor_id == spec.vendor_id and hid_device.product_id == spec.product_id:
-                devices_by_path[hid_device.path] = name
+                devices.append(name)
 
-    return list(devices_by_path.items())
+    return devices
 
 
 def get_supported_devices() -> List[Tuple[str, int, int]]:
@@ -321,3 +321,35 @@ def open_with_config(
         device=device,
         device_index=device_index,
     )
+
+
+def get_connected_paths_and_names() -> Tuple[List[str], List[str]]:
+    """Return the paths and names of the supported devices currently connected.
+
+    Returns:
+        Tuple of two lists: (device_paths, device_names).
+        Tuple of empty lists if no supported devices are found.
+
+    Raises:
+        RuntimeError: If HID API is not installed.
+    """
+    try:
+        hid = Enumeration()
+    except AttributeError as e:
+        raise RuntimeError(
+            "HID API is probably not installed. See https://spacemouse.kubaandrysek.cz for details."
+        ) from e
+
+    device_specs = get_device_specs()
+    device_paths = []
+    device_names = []
+
+    # hid.find() is all connected HID devices,
+    # device_specs is all supported Spacemouse devices.
+    for hid_device in hid.find():
+        for name, spec in device_specs.items():
+            if hid_device.vendor_id == spec.vendor_id and hid_device.product_id == spec.product_id:
+                device_paths.append(hid_device.path)
+                device_names.append(name)
+
+    return device_paths, device_names

--- a/pyspacemouse/pyspacemouse_cli.py
+++ b/pyspacemouse/pyspacemouse_cli.py
@@ -16,8 +16,8 @@ def list_spacemouse_cli():
     devices = pyspacemouse.get_connected_devices()
     if devices:
         print("Connected SpaceMouse devices:")
-        for _, device in devices:
-            print(f"  - {device}")
+        for path, device in devices:
+            print(f"  - {device} ({path})")
     else:
         print("No connected SpaceMouse devices found.")
 

--- a/pyspacemouse/pyspacemouse_cli.py
+++ b/pyspacemouse/pyspacemouse_cli.py
@@ -13,10 +13,10 @@ def print_version_cli():
 
 def list_spacemouse_cli():
     """List connected SpaceMouse devices."""
-    devices = pyspacemouse.get_connected_devices()
+    devices = pyspacemouse.get_connected_spacemice()
     if devices:
         print("Connected SpaceMouse devices:")
-        for device in devices:
+        for _, device in devices:
             print(f"  - {device}")
     else:
         print("No connected SpaceMouse devices found.")

--- a/pyspacemouse/pyspacemouse_cli.py
+++ b/pyspacemouse/pyspacemouse_cli.py
@@ -13,7 +13,7 @@ def print_version_cli():
 
 def list_spacemouse_cli():
     """List connected SpaceMouse devices."""
-    devices = pyspacemouse.get_connected_spacemice()
+    devices = pyspacemouse.get_connected_devices()
     if devices:
         print("Connected SpaceMouse devices:")
         for _, device in devices:

--- a/pyspacemouse/pyspacemouse_cli.py
+++ b/pyspacemouse/pyspacemouse_cli.py
@@ -59,7 +59,7 @@ def test_connect_cli():
 
             while True:
                 state = device.read()
-                if state.nonzero():
+                if state.has_motion():
                     print(
                         f"x={state.x:+.2f} y={state.y:+.2f} z={state.z:+.2f} "
                         f"roll={state.roll:+.2f} pitch={state.pitch:+.2f} yaw={state.yaw:+.2f}"

--- a/pyspacemouse/pyspacemouse_cli.py
+++ b/pyspacemouse/pyspacemouse_cli.py
@@ -13,10 +13,10 @@ def print_version_cli():
 
 def list_spacemouse_cli():
     """List connected SpaceMouse devices."""
-    devices = pyspacemouse.get_connected_devices()
-    if devices:
+    connected = pyspacemouse.get_connected_paths_and_names()
+    if connected:
         print("Connected SpaceMouse devices:")
-        for path, device in devices:
+        for path, device in connected.items():
             print(f"  - {device} ({path})")
     else:
         print("No connected SpaceMouse devices found.")
@@ -59,15 +59,11 @@ def test_connect_cli():
 
             while True:
                 state = device.read()
-                if any(
-                    abs(val) > 0.01
-                    for val in [state.x, state.y, state.z, state.roll, state.pitch, state.yaw]
-                ):
+                if state.nonzero():
                     print(
                         f"x={state.x:+.2f} y={state.y:+.2f} z={state.z:+.2f} "
                         f"roll={state.roll:+.2f} pitch={state.pitch:+.2f} yaw={state.yaw:+.2f}"
                     )
-                time.sleep(0.01)
 
     except RuntimeError as e:
         print(f"Failed to open SpaceMouse: {e}")

--- a/pyspacemouse/pyspacemouse_cli.py
+++ b/pyspacemouse/pyspacemouse_cli.py
@@ -13,7 +13,7 @@ def print_version_cli():
 
 def list_spacemouse_cli():
     """List connected SpaceMouse devices."""
-    connected = pyspacemouse.get_connected_paths_and_names()
+    connected = pyspacemouse.get_connected_devices_by_path()
     if connected:
         print("Connected SpaceMouse devices:")
         for path, device in connected.items():

--- a/pyspacemouse/types.py
+++ b/pyspacemouse/types.py
@@ -87,6 +87,13 @@ class SpaceMouseState:
         """Allow dict-like access for backward compatibility."""
         return getattr(self, key)
 
+    def nonzero(self, threshold: float = 0.01) -> bool:
+        """
+        Check if any axis value exceeds the given threshold.
+        Used in example scripts to avoid printing zero values when the device is at rest.
+        """
+        return any(abs(getattr(self, axis)) > threshold for axis in AXIS_NAMES)
+
 
 @dataclass(frozen=True, slots=True)
 class DeviceInfo:

--- a/pyspacemouse/types.py
+++ b/pyspacemouse/types.py
@@ -87,7 +87,7 @@ class SpaceMouseState:
         """Allow dict-like access for backward compatibility."""
         return getattr(self, key)
 
-    def nonzero(self, threshold: float = 0.01) -> bool:
+    def has_motion(self, threshold: float = 0.01) -> bool:
         """
         Check if any axis value exceeds the given threshold.
         Used in example scripts to avoid printing zero values when the device is at rest.

--- a/tests/hidapi_test.py
+++ b/tests/hidapi_test.py
@@ -6,7 +6,6 @@
 #     while 1:
 #         state = pyspacemouse.read()
 #         print(state.x, state.y, state.z)
-#         time.sleep(0.01)
 import time
 
 import hid

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -44,17 +44,14 @@
 #     callback()
 
 
-import time
-
 import pyspacemouse
 
 success = pyspacemouse.open(
     dof_callback=pyspacemouse.print_state, button_callback=pyspacemouse.print_buttons
 )
 if success:
-    while 1:
+    while True:
         state = pyspacemouse.read()
-        time.sleep(0.01)
 
 # import pyspacemouse
 # import time


### PR DESCRIPTION
The `get_connected_devices` function only returns device type names, e.g. `SpaceMouseCompact` or `SpaceMousePro`. But these names do not uniquely identify the device. If you have two of the same device, you cannot know which one is which. 

The new function `get_connected_paths_and_names()` returns both file paths and names (e.g. `[('SpaceMouseCompact', '/dev/hidraw4')]`)

For example, you can now get print out of the device names (types) and paths:
```bash
(pyspacemouse) peter@T15:~/code/PySpaceMouse$ pyspacemouse --list-connected
(pyspacemouse) peter@T15:~/code/PySpaceMouse$ pyspacemouse --list-connected
Connected SpaceMouse devices:
  - SpaceMouseCompact (/dev/hidraw2)
  - SpaceMouseWirelessNew (/dev/hidraw3)
```