### PR TITLE
Add ability to rearrange axes

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,17 @@ with pyspacemouse.open(
 
 ### Custom Axis Mapping
 
-Customize axis directions for specific coordinate conventions (ROS, OpenGL, etc.):
+Choose a built-in convention for common application frames:
+
+```python
+import pyspacemouse
+from pyspacemouse import AxisConvention
+
+with pyspacemouse.open(axis_convention=AxisConvention.ROS) as device:
+    state = device.read()
+```
+
+For custom coordinate frames, remap or invert axes explicitly:
 
 ```python
 import pyspacemouse
@@ -189,10 +199,9 @@ import pyspacemouse
 specs = pyspacemouse.get_device_specs()
 base = specs["SpaceNavigator"]
 
-# Invert axes for your application
 custom = pyspacemouse.modify_device_info(
     base,
-    invert_axes=["y", "z", "roll", "yaw"],  # Invert these
+    remap_axes={"x": "y", "y": ("x", -1), "yaw": ("yaw", -1)},
 )
 
 with pyspacemouse.open(device_spec=custom) as device:

--- a/docs/README.md
+++ b/docs/README.md
@@ -180,7 +180,17 @@ with pyspacemouse.open(
 
 ### Custom Axis Mapping
 
-Customize axis directions for specific coordinate conventions (ROS, OpenGL, etc.):
+Choose a built-in convention for common application frames:
+
+```python
+import pyspacemouse
+from pyspacemouse import AxisConvention
+
+with pyspacemouse.open(axis_convention=AxisConvention.ROS) as device:
+    state = device.read()
+```
+
+For custom coordinate frames, remap or invert axes explicitly:
 
 ```python
 import pyspacemouse
@@ -189,10 +199,9 @@ import pyspacemouse
 specs = pyspacemouse.get_device_specs()
 base = specs["SpaceNavigator"]
 
-# Invert axes for your application
 custom = pyspacemouse.modify_device_info(
     base,
-    invert_axes=["y", "z", "roll", "yaw"],  # Invert these
+    remap_axes={"x": "y", "y": ("x", -1), "yaw": ("yaw", -1)},
 )
 
 with pyspacemouse.open(device_spec=custom) as device:

--- a/docs/mouseApi/index.md
+++ b/docs/mouseApi/index.md
@@ -76,6 +76,8 @@ The same `axis_convention` argument is available on `open_by_path()` and
 |------------|------------------|------------------------------------------------|--------------------------------------------------------------------------------------------------------------------|
 | `AxisConvention.HID` | `+x` right, `+y` toward the user, `+z` down | right-handed                                   | USB HID convention; see [HID Usage Tables, 4.2 Axis Usages](https://usb.org/document-library/hid-usage-tables-17). |
 | `AxisConvention.HID_Z_UP` | `+x` right, `+y` away from the user, `+z` up | right-handed                                   | HID frame, rotated -180 degrees about +X so Z points up                                                            |
+| `AxisConvention.ROS` | `+x` forward, `+y` left, `+z` up | right-handed                                   | ROS REP 103 body frame.                                                                                            |
+| `AxisConvention.UNITY` | `+x` right, `+y` up, `+z` forward | left-handed                                    | Unity world/object frame.                                                                                          |
 | `AxisConvention.LEGACY` | `x=+HID_x`, `y=-HID_y`, `z=-HID_z` | `roll=-HID_Ry`, `pitch=-HID_Rx`, `yaw=+HID_Rz` | Deprecated. Default for backward compatibility.                                                                    |
 
 For new code, select a convention that matches your need. Use `AxisConvention.LEGACY` only for existing code that
@@ -112,17 +114,20 @@ custom = pyspacemouse.create_device_info(
 
 ### `modify_device_info()`
 
-Modify an existing device spec (e.g., to invert axes):
+Modify an existing device spec (e.g., to remap or invert axes):
 
 ```python
 specs = pyspacemouse.get_device_specs()
 base = specs["SpaceNavigator"]
 
-# Invert Y and Z for ROS conventions
-ros_spec = pyspacemouse.modify_device_info(
+custom = pyspacemouse.modify_device_info(
     base,
-    name="SpaceNavigator (ROS)",
-    invert_axes=["y", "z", "roll", "yaw"],
+    name="SpaceNavigator (Custom)",
+    remap_axes={
+        "x": "y",
+        "y": ("x", -1),
+        "yaw": ("yaw", -1),
+    },
 )
 ```
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -10,7 +10,17 @@ The library applies some axis inversions to make values more intuitive:
 - **Y axis**: Inverted for common conventions
 - **Rotations**: pitch/roll inverted from HID spec
 
-If your application needs different conventions (e.g., ROS, OpenGL), use the `modify_device_info()` function:
+If your application needs a common coordinate convention, pass it when opening the device:
+
+```python
+import pyspacemouse
+from pyspacemouse import AxisConvention
+
+with pyspacemouse.open(axis_convention=AxisConvention.ROS) as device:
+    state = device.read()
+```
+
+For custom conventions, use `modify_device_info()` to remap or invert axes:
 
 ```python
 import pyspacemouse
@@ -18,10 +28,9 @@ import pyspacemouse
 specs = pyspacemouse.get_device_specs()
 base = specs["SpaceNavigator"]
 
-# Customize axes for your application
 custom = pyspacemouse.modify_device_info(
     base,
-    invert_axes=["y", "z", "roll", "yaw"],  # Axes to flip
+    remap_axes={"x": "y", "y": ("x", -1), "yaw": ("yaw", -1)},
 )
 
 with pyspacemouse.open(device_spec=custom) as device:

--- a/pyspacemouse/api.py
+++ b/pyspacemouse/api.py
@@ -123,7 +123,8 @@ def _create_and_open_device(
                 "AxisConvention.LEGACY is deprecated for built-in device specs "
                 "and will be removed in a future release. Pass "
                 "axis_convention=AxisConvention.HID_Z_UP for the recommended "
-                "right-handed Z-up frame, or AxisConvention.HID for raw HID axes.",
+                "right-handed Z-up frame, other values on AxisConvention for application-specific frames, or "
+                "AxisConvention.HID for raw HID axes.",
                 DeprecationWarning,
                 stacklevel=3,
             )
@@ -173,8 +174,9 @@ def open_by_path(
         axis_convention: Coordinate convention for axis values. If None,
                          uses the deprecated legacy convention for backward
                          compatibility. Use AxisConvention.HID_Z_UP for a
-                         right-handed Z-up frame. Mutually exclusive with
-                         device_spec.
+                         right-handed Z-up frame, AxisConvention.ROS for ROS,
+                         or AxisConvention.UNITY for Unity. Mutually exclusive
+                         with device_spec.
 
     Returns:
         SpaceMouseDevice instance (use as context manager for auto-cleanup)
@@ -280,8 +282,10 @@ def open(
         axis_convention: Coordinate convention for axis values. If None,
                          uses the deprecated legacy convention for backward
                          compatibility. Use AxisConvention.HID_Z_UP for a
-                         geometrically consistent right-handed Z-up frame, or
-                         AxisConvention.HID for raw HID values (Z down).
+                         geometrically consistent right-handed Z-up frame,
+                         AxisConvention.ROS for ROS, AxisConvention.UNITY for
+                         Unity, or AxisConvention.HID for raw HID values
+                         (Z down).
                          Mutually exclusive with device_spec.
 
     Returns:

--- a/pyspacemouse/config_helpers.py
+++ b/pyspacemouse/config_helpers.py
@@ -5,12 +5,11 @@ for custom axis mappings and device configurations.
 
 Example:
     import pyspacemouse
-    from pyspacemouse import create_device_info, modify_device_info
+    from pyspacemouse import modify_device_info
 
-    # Modify existing device to invert Y axis
+    # Grab a built-in spec and invert Y in its current convention.
     specs = pyspacemouse.get_device_specs()
-    base = specs["SpaceNavigator"]
-    custom = modify_device_info(base, invert_axes=["y", "pitch"])
+    custom = modify_device_info(specs["SpaceNavigator"], invert_axes=["y"])
 
     with pyspacemouse.open(device_spec=custom) as device:
         state = device.read()
@@ -18,7 +17,120 @@ Example:
 
 from __future__ import annotations
 
-from .types import AxisConvention, AxisSpec, ButtonSpec, DeviceInfo
+from typing import Dict, Literal, Tuple, Union
+
+from .types import AXIS_NAMES, Axis, AxisConvention, AxisSpec, ButtonSpec, DeviceInfo
+
+# Maps each *output* axis to the *source* axis whose data it should read,
+# optionally with a sign. Direction is output <- source:
+#   {"x": "z"}            output x reads source z          (sign +1)
+#   {"x": ("z", -1)}      output x reads source z, negated
+#   {"x": "y", "y": "x"}  swap x and y (applied atomically; see modify_device_info)
+# typing.Dict/Tuple/Union (not PEP 604) is required: this alias is evaluated at
+# runtime and must import on Python 3.8.
+AxisRemap = Dict[Axis, Union[Axis, Tuple[Axis, Literal[-1, 1]]]]
+
+# Remaps from the HID convention to each named convention.
+_HID_TO_CONVENTION: dict[AxisConvention, AxisRemap] = {
+    AxisConvention.LEGACY: {
+        "x": ("x", 1),
+        "y": ("y", -1),
+        "z": ("z", -1),
+        "roll": ("pitch", -1),
+        "pitch": ("roll", -1),
+        "yaw": ("yaw", 1),
+    },
+    AxisConvention.HID_Z_UP: {
+        "x": ("x", 1),
+        "y": ("y", -1),
+        "z": ("z", -1),
+        "roll": ("roll", 1),
+        "pitch": ("pitch", -1),
+        "yaw": ("yaw", -1),
+    },
+    AxisConvention.ROS: {
+        "x": ("y", -1),
+        "y": ("x", -1),
+        "z": ("z", -1),
+        "roll": ("pitch", -1),
+        "pitch": ("roll", -1),
+        "yaw": ("yaw", -1),
+    },
+    AxisConvention.UNITY: {
+        "x": ("x", 1),
+        "y": ("z", -1),
+        "z": ("y", -1),
+        "roll": ("roll", -1),
+        "pitch": ("yaw", 1),
+        "yaw": ("pitch", 1),
+    },
+}
+
+
+def _parse_axis_remap(
+    target_axis: str, remap: Axis | tuple[Axis, Literal[-1, 1]]
+) -> tuple[Axis, int]:
+    if target_axis not in AXIS_NAMES:
+        raise ValueError(f"Unknown target axis: {target_axis!r}. Valid axes: {list(AXIS_NAMES)}")
+
+    if isinstance(remap, tuple):
+        source_axis, sign = remap
+    else:
+        source_axis, sign = remap, 1
+
+    if source_axis not in AXIS_NAMES:
+        raise ValueError(f"Unknown source axis: {source_axis!r}. Valid axes: {list(AXIS_NAMES)}")
+    if sign not in (-1, 1):
+        raise ValueError(f"Axis remap sign for {target_axis!r} must be 1 or -1.")
+
+    return source_axis, sign
+
+
+def _copy_axis_spec(spec: AxisSpec, sign: int = 1) -> AxisSpec:
+    return AxisSpec(
+        channel=spec.channel,
+        byte1=spec.byte1,
+        byte2=spec.byte2,
+        scale=spec.scale * sign,
+    )
+
+
+def _normalize_to_hid(spec: DeviceInfo) -> DeviceInfo:
+    """Convert any named-convention DeviceInfo to HID convention.
+
+    For LEGACY input, applies the LEGACY→HID forward remap.
+    For any other named convention C, inverts the HID→C remap: because
+    sign ∈ {-1, 1}, the inverse has the same sign, only source and target
+    are swapped.
+    """
+    if spec.convention == AxisConvention.HID:
+        return spec
+
+    if spec.convention not in _HID_TO_CONVENTION:
+        raise ValueError(
+            f"Cannot normalize {spec.convention!r} to HID — only named conventions "
+            "can be automatically normalized. "
+            "A spec with no convention (None) has no defined inverse."
+        )
+
+    # Invert HID→C to get C→HID:
+    # HID[hid_target] = C[c_source] * sign  →  C[c_source] = HID[hid_target] * sign
+    new_mappings = {}
+    for hid_target, src in _HID_TO_CONVENTION[spec.convention].items():
+        c_source, sign = _parse_axis_remap(hid_target, src)
+        new_mappings[hid_target] = _copy_axis_spec(spec.mappings[c_source], sign)
+
+    return DeviceInfo(
+        name=spec.name,
+        vendor_id=spec.vendor_id,
+        product_id=spec.product_id,
+        led_id=spec.led_id,
+        axis_scale=spec.axis_scale,
+        mappings=new_mappings,
+        button_specs=spec.button_specs,
+        button_names=spec.button_names,
+        convention=AxisConvention.HID,
+    )
 
 
 def create_device_info(
@@ -29,6 +141,7 @@ def create_device_info(
     buttons: dict[str, tuple[int, int, int]] | None = None,
     led_id: tuple[int, int] | None = None,
     axis_scale: float = 350.0,
+    convention: AxisConvention | None = None,
 ) -> DeviceInfo:
     """Create a DeviceInfo from Python dictionaries.
 
@@ -44,6 +157,8 @@ def create_device_info(
         buttons: Optional dict mapping button names to (channel, byte, bit)
         led_id: Optional tuple (report_id, on_value) for LED control
         axis_scale: Scaling factor for axis values (default 350.0)
+        convention: Axis convention used by the spec, or None for a spec
+                    that follows no named convention (default None).
 
     Returns:
         DeviceInfo instance ready for use with open()
@@ -64,7 +179,6 @@ def create_device_info(
             buttons={"LEFT": (3, 1, 0), "RIGHT": (3, 1, 1)},
         )
     """
-    # Parse mappings
     axis_specs = {}
     for axis, values in mappings.items():
         axis_specs[axis] = AxisSpec(
@@ -74,7 +188,6 @@ def create_device_info(
             scale=values[3],
         )
 
-    # Parse buttons
     button_specs = []
     button_names = []
     if buttons:
@@ -91,81 +204,44 @@ def create_device_info(
         mappings=axis_specs,
         button_specs=tuple(button_specs),
         button_names=tuple(button_names),
+        convention=convention,
     )
 
 
 def apply_axis_convention(base: DeviceInfo, convention: AxisConvention) -> DeviceInfo:
-    """Apply an axis convention to a DeviceInfo, returning a corrected copy.
+    """Convert a DeviceInfo from any named convention to another.
 
-    This function understands the internal structure of specs loaded from
-    devices.toml (the *legacy* convention) and remaps byte assignments and
-    scales to produce a geometrically consistent coordinate frame.
-
-    Legacy byte layout (assumed for all devices.toml entries):
-      - 'x'     bytes → HID Tx  (scale +1)
-      - 'y'     bytes → HID Ty  (scale −1, inverted)
-      - 'z'     bytes → HID Tz  (scale −1, inverted)
-      - 'pitch' bytes → HID Rx  (scale −1)   ← label is intentionally "wrong"
-      - 'roll'  bytes → HID Ry  (scale −1)   ← label is intentionally "wrong"
-      - 'yaw'   bytes → HID Rz  (scale +1)
-
-    Do NOT call this on a DeviceInfo that was already produced by this function
-    or that uses a non-legacy mapping — the result would be incorrect.
+    Normalizes the input to HID first (via _normalize_to_hid), then applies
+    the HID→target remap from _HID_TO_CONVENTION.  Works for any pair of named
+    conventions.
 
     Args:
-        base: DeviceInfo from get_device_specs() (legacy convention).
+        base: DeviceInfo in any named convention (LEGACY, HID, ROS, …).
         convention: Target AxisConvention.
 
     Returns:
-        New DeviceInfo with remapped axes.  LEGACY returns *base* unchanged.
+        New DeviceInfo in the requested convention.  Returns *base* unchanged
+        if it is already in the requested convention.
+
+    Raises:
+        ValueError: If base has no named convention (convention is None) and so
+            cannot be normalized to HID.
     """
     convention = AxisConvention(convention)
 
-    if convention == AxisConvention.LEGACY:
+    if base.convention == convention:
         return base
 
-    m = base.mappings
-    new_m: dict = {}
-
-    # ── Translation axes ──────────────────────────────────────────────────────
-    for axis in ("x", "y", "z"):
-        if axis not in m:
-            continue
-        spec = m[axis]
-        if convention == AxisConvention.HID:
-            # HID: all raw values are positive
-            new_m[axis] = AxisSpec(spec.channel, spec.byte1, spec.byte2, 1)
-        else:
-            # HID_Z_UP: same translation signs as legacy (x=+1, y=−1, z=−1)
-            new_m[axis] = spec
-
-    # ── Rotation axes ─────────────────────────────────────────────────────────
-    # In the legacy TOML the byte *positions* are correct but the names and
-    # signs are wrong.  The bytes labelled 'pitch' hold raw HID Rx (rotation
-    # around X), 'roll' holds HID Ry, and 'yaw' holds HID Rz.
-    hid_rx = m.get("pitch")  # legacy 'pitch' bytes  =  HID Rx
-    hid_ry = m.get("roll")  # legacy 'roll'  bytes  =  HID Ry
-    hid_rz = m.get("yaw")  # legacy 'yaw'   bytes  =  HID Rz
+    hid_base = _normalize_to_hid(base)
 
     if convention == AxisConvention.HID:
-        # roll=+HID_Rx, pitch=+HID_Ry, yaw=+HID_Rz  (all positive)
-        if hid_rx:
-            new_m["roll"] = AxisSpec(hid_rx.channel, hid_rx.byte1, hid_rx.byte2, 1)
-        if hid_ry:
-            new_m["pitch"] = AxisSpec(hid_ry.channel, hid_ry.byte1, hid_ry.byte2, 1)
-        if hid_rz:
-            new_m["yaw"] = AxisSpec(hid_rz.channel, hid_rz.byte1, hid_rz.byte2, 1)
-    else:  # HID_Z_UP
-        # roll=+HID_Rx, pitch=−HID_Ry, yaw=−HID_Rz
-        # Derivation: Z_up = −Z_hid, Y_back = −Y_hid.
-        # Rotation around Y_back = −rotation around Y_hid → pitch = −HID_Ry
-        # Rotation around Z_up   = −rotation around Z_hid → yaw   = −HID_Rz
-        if hid_rx:
-            new_m["roll"] = AxisSpec(hid_rx.channel, hid_rx.byte1, hid_rx.byte2, 1)
-        if hid_ry:
-            new_m["pitch"] = AxisSpec(hid_ry.channel, hid_ry.byte1, hid_ry.byte2, -1)
-        if hid_rz:
-            new_m["yaw"] = AxisSpec(hid_rz.channel, hid_rz.byte1, hid_rz.byte2, -1)
+        return hid_base
+
+    remap = _HID_TO_CONVENTION[convention]
+    new_mappings = dict(hid_base.mappings)
+    for target_axis, src in remap.items():
+        source_axis, sign = _parse_axis_remap(target_axis, src)
+        new_mappings[target_axis] = _copy_axis_spec(hid_base.mappings[source_axis], sign)
 
     return DeviceInfo(
         name=base.name,
@@ -173,59 +249,80 @@ def apply_axis_convention(base: DeviceInfo, convention: AxisConvention) -> Devic
         product_id=base.product_id,
         led_id=base.led_id,
         axis_scale=base.axis_scale,
-        mappings=new_m,
+        mappings=new_mappings,
         button_specs=base.button_specs,
         button_names=base.button_names,
+        convention=convention,
     )
 
 
 def modify_device_info(
     base: DeviceInfo,
     name: str | None = None,
-    invert_axes: list[str] | None = None,
+    remap_axes: AxisRemap | None = None,
+    invert_axes: list[Axis] | None = None,
     axis_scale: float | None = None,
 ) -> DeviceInfo:
     """Create a modified DeviceInfo from an existing one.
 
-    This is useful for adjusting axis conventions without redefining
-    the entire device configuration.
+    remap_axes and invert_axes operate directly on the slots of the input spec
+    in its current convention. The input convention is preserved for name/scale-only
+    changes; convention is set to None when axes are modified.
 
     Args:
-        base: Existing DeviceInfo to modify
-        name: Optional new name for the device
-        invert_axes: List of axis names to invert (e.g., ["y", "roll"])
-        axis_scale: Optional new axis scale value
+        base: Existing DeviceInfo to modify.
+        name: Optional new name for the device.
+        remap_axes: Optional mapping of each output axis to the source axis whose
+                    data it should read (direction: output <- source). A value is
+                    either a source axis name, or an (axis, sign) tuple to flip
+                    sign in the same step. Reads are taken from the *original*
+                    spec, so swaps such as {"x": "y", "y": "x"} apply atomically.
+                    Example: {"x": ("z", -1)} makes output x read negated z.
+        invert_axes: Axis names to negate, e.g. ["y", "roll"]. A convenience for
+                     the common case; invert_axes=["y"] equals
+                     remap_axes={"y": ("y", -1)}. Mutually exclusive with
+                     remap_axes — when remapping, express inversions as (axis, -1)
+                     tuples there instead.
+        axis_scale: Optional new axis scale value.
 
     Returns:
-        New DeviceInfo with modifications applied
+        New DeviceInfo with modifications applied.
+
+    Raises:
+        ValueError: If both remap_axes and invert_axes are given.
 
     Example:
-        # Get existing device spec and invert axes for ROS conventions
         specs = pyspacemouse.get_device_specs()
-        base = specs["SpaceNavigator"]
-        ros_compatible = modify_device_info(
-            base,
-            name="SpaceNavigator (ROS)",
-            invert_axes=["y", "z", "roll", "yaw"],
+        tweaked = modify_device_info(
+            specs["SpaceNavigator"],
+            invert_axes=["y"],
         )
     """
-    # Start with base values
+    if remap_axes and invert_axes:
+        raise ValueError(
+            "remap_axes and invert_axes are mutually exclusive; express inversions "
+            "as (axis, -1) tuples inside remap_axes instead, e.g. {'z': ('z', -1)}."
+        )
+
     new_name = name if name is not None else base.name
     new_scale = axis_scale if axis_scale is not None else base.axis_scale
 
-    # Copy and optionally invert mappings
-    new_mappings = {}
-    for axis, spec in base.mappings.items():
-        if invert_axes and axis in invert_axes:
-            new_mappings[axis] = AxisSpec(
-                channel=spec.channel,
-                byte1=spec.byte1,
-                byte2=spec.byte2,
-                scale=-spec.scale,  # Invert
-            )
-        else:
-            new_mappings[axis] = spec
+    new_mappings = dict(base.mappings)
+    if remap_axes:
+        for target_axis, remap in remap_axes.items():
+            source_axis, sign = _parse_axis_remap(target_axis, remap)
+            if source_axis not in base.mappings:
+                raise ValueError(f"Cannot remap missing source axis: {source_axis!r}.")
+            new_mappings[target_axis] = _copy_axis_spec(base.mappings[source_axis], sign)
 
+    for axis in invert_axes or []:
+        if axis not in AXIS_NAMES:
+            raise ValueError(f"Unknown axis to invert: {axis!r}. Valid axes: {list(AXIS_NAMES)}")
+        if axis not in new_mappings:
+            raise ValueError(f"Cannot invert missing axis: {axis!r}.")
+        new_mappings[axis] = _copy_axis_spec(new_mappings[axis], -1)
+
+    axes_modified = bool(remap_axes or invert_axes)
     return DeviceInfo(
         name=new_name,
         vendor_id=base.vendor_id,
@@ -235,4 +332,5 @@ def modify_device_info(
         mappings=new_mappings,
         button_specs=base.button_specs,
         button_names=base.button_names,
+        convention=None if axes_modified else base.convention,
     )

--- a/pyspacemouse/config_helpers.py
+++ b/pyspacemouse/config_helpers.py
@@ -31,7 +31,7 @@ from .types import AXIS_NAMES, Axis, AxisConvention, AxisSpec, ButtonSpec, Devic
 AxisRemap = Dict[Axis, Union[Axis, Tuple[Axis, Literal[-1, 1]]]]
 
 # Remaps from the HID convention to each named convention.
-_HID_TO_CONVENTION: dict[AxisConvention, AxisRemap] = {
+_HID_TO_CONVENTION: Dict[AxisConvention, AxisRemap] = {
     AxisConvention.LEGACY: {
         "x": ("x", 1),
         "y": ("y", -1),

--- a/pyspacemouse/types.py
+++ b/pyspacemouse/types.py
@@ -20,8 +20,7 @@ AXIS_NAMES: tuple[Axis, ...] = ("x", "y", "z", "roll", "pitch", "yaw")
 class AxisConvention(str, Enum):
     """Coordinate convention for SpaceMouse axis values.
 
-    All three conventions produce a valid right-handed coordinate system
-    (except LEGACY, which is kept only for backward compatibility).
+    All conventions except LEGACY produce a consistent coordinate system.
 
     Attributes:
         LEGACY: The original library convention. Default for backward compat.
@@ -38,11 +37,20 @@ class AxisConvention(str, Enum):
             Translation: X=+HID_x, Y=-HID_y (away from user), Z=-HID_z (up).
             Rotation: roll=+HID_Rx (around X), pitch=−HID_Ry (around Y),
             yaw=−HID_Rz (positive = counterclockwise from above).
+        ROS: ROS REP 103 body convention.
+            Translation: X forward, Y left, Z up.
+            Rotation: roll around X, pitch around Y, yaw around Z.
+        UNITY: Unity left-handed convention.
+            Translation: X right, Y up, Z forward.
+            Rotation: roll around X, pitch around Y, yaw around Z using
+            Unity's left-handed positive rotation direction.
     """
 
     LEGACY = "legacy"
     HID = "hid"
     HID_Z_UP = "hid_z_up"
+    ROS = "ros"
+    UNITY = "unity"
 
 
 @dataclass(frozen=True, slots=True)
@@ -147,6 +155,7 @@ class DeviceInfo:
     mappings: dict[Axis, AxisSpec]
     button_specs: tuple[ButtonSpec, ...]
     button_names: tuple[str, ...]
+    convention: AxisConvention | None = AxisConvention.LEGACY
 
     @property
     def hid_id(self) -> tuple[int, int]:

--- a/pyspacemouse/types.py
+++ b/pyspacemouse/types.py
@@ -20,7 +20,7 @@ AXIS_NAMES: tuple[Axis, ...] = ("x", "y", "z", "roll", "pitch", "yaw")
 class AxisConvention(str, Enum):
     """Coordinate convention for SpaceMouse axis values.
 
-    All conventions except LEGACY produce a consistent coordinate system.
+    All conventions except LEGACY produce a consistently left or right handed coordinate system. LEGACY is neither.
 
     Attributes:
         LEGACY: The original library convention. Default for backward compat.


### PR DESCRIPTION
Common alternative axis conventions (ROS, Unity https://github.com/JakubAndrysek/PySpaceMouse/pull/50#issuecomment-4701839726) would require swapping axes (not merely inverting them). This wasn't supported, so this PR adds that ability. Not 100% sure on this design but figure you may already be thinking about it

**`apply_axis_convention()` generalized**. Previously only accepted LEGACY specs as input. Now converts between any pair of named conventions via an internal HID normalization step. `DeviceInfo` gained a `convention` field (default `AxisConvention.LEGACY`) to track this.

**`modify_device_info()` extended**. New `remap_axes: AxisRemap` parameter for axis swaps and sign flips in one step. `remap_axes` and `invert_axes` are mutually exclusive. Returns `convention=None` when axes are modified, preserves the input convention (newly tracked on the object, per above) otherwise.

New:

- `AxisConvention.ROS`, `AxisConvention.UNITY`
- `AxisRemap`  type alias
- `modify_device_info(remap_axes=...)` new parameter
- `create_device_info(convention=...)` new parameter
- `DeviceInfo.convention` new field (default `AxisConvention.LEGACY`, backward compatible)

## Summary by Sourcery

Add support for named axis conventions and flexible axis remapping to better match common coordinate frames such as ROS and Unity.

New Features:
- Allow converting DeviceInfo specs between any named axis convention via HID normalization in apply_axis_convention().
- Introduce AxisRemap-based axis remapping and explicit inversion in modify_device_info() for swapping and flipping axes in one step.
- Add ROS and Unity axis conventions and track the axis convention directly on DeviceInfo, including via a new convention parameter on create_device_info().

Enhancements:
- Generalize axis_convention usage in the public API to cover multiple application-specific frames instead of only HID/HID_Z_UP.
- Improve validation and error handling around axis remapping and inversion operations.

Documentation:
- Document the new ROS and Unity axis conventions in the mouse API reference.
- Update README and troubleshooting guides to show using axis_convention and the new remap_axes parameter for custom coordinate frames.