### PR TITLE
Add CI testing of axis convention remapping

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,10 +41,10 @@ jobs:
               run: |
                   sudo apt-get update
                   sudo apt-get install -y libhidapi-dev
-            - name: Install Hatch
-              run: pip install hatch
+            - name: Install test dependencies
+              run: python -m pip install -e . pytest pytest-cov
             - name: Run axis convention tests
-              run: hatch run test:pytest tests/test_axis_conventions.py
+              run: python -m pytest tests/test_axis_conventions.py
 
     # test:
     #     needs: lint

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,25 @@ jobs:
             - name: Run Ruff linting
               run: hatch run ruff check .
 
+    test:
+        needs: lint
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0  # Required for hatch-vcs to determine version
+            - uses: actions/setup-python@v5
+              with:
+                  python-version: "3.12"
+            - name: Install system dependencies
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install -y libhidapi-dev
+            - name: Install Hatch
+              run: pip install hatch
+            - name: Run axis convention tests
+              run: hatch run test:pytest tests/test_axis_conventions.py
+
     # test:
     #     needs: lint
     #     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,10 @@ jobs:
 
     test:
         needs: lint
+        strategy:
+            fail-fast: false
+            matrix:
+                python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
@@ -32,7 +36,7 @@ jobs:
                   fetch-depth: 0  # Required for hatch-vcs to determine version
             - uses: actions/setup-python@v5
               with:
-                  python-version: "3.12"
+                  python-version: ${{ matrix.python-version }}
             - name: Install system dependencies
               run: |
                   sudo apt-get update

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,23 +117,25 @@ If you don't want to modify the library, use `create_device_info()`:
 ```python
 import pyspacemouse
 
-device_spec = pyspacemouse.create_device_info({
-    "name": "MyCustomDevice",
-    "hid_id": [0x256F, 0xC652],
-    "axis_scale": 350.0,
-    "mappings": {
-        "x": [1, 1, 2, 1],
-        "y": [1, 3, 4, -1],
-        "z": [1, 5, 6, -1],
-        "pitch": [2, 1, 2, -1],
-        "roll": [2, 3, 4, -1],
-        "yaw": [2, 5, 6, 1],
-    },
-    "buttons": {
-        "LEFT": [3, 1, 0],
-        "RIGHT": [3, 1, 1],
-    },
-})
+device_spec = pyspacemouse.create_device_info(
+    {
+        "name": "MyCustomDevice",
+        "hid_id": [0x256F, 0xC652],
+        "axis_scale": 350.0,
+        "mappings": {
+            "x": [1, 1, 2, 1],
+            "y": [1, 3, 4, -1],
+            "z": [1, 5, 6, -1],
+            "pitch": [2, 1, 2, -1],
+            "roll": [2, 3, 4, -1],
+            "yaw": [2, 5, 6, 1],
+        },
+        "buttons": {
+            "LEFT": [3, 1, 0],
+            "RIGHT": [3, 1, 1],
+        },
+    }
+)
 
 with pyspacemouse.open(device_spec=device_spec) as device:
     state = device.read()

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ with pyspacemouse.open() as device:
     state = device.read()
 
     # 6-DOF axes (range: -1.0 to 1.0)
-    print(state.x, state.y, state.z)       # Translation
+    print(state.x, state.y, state.z)  # Translation
     print(state.roll, state.pitch, state.yaw)  # Rotation
 
     # Buttons (list of 0/1)
@@ -149,9 +149,11 @@ mapping table. Custom
 import pyspacemouse
 import time
 
+
 # Button callback
 def on_button(state, buttons, pressed):
     print(f"Button {pressed} pressed!")
+
 
 button_callbacks = [
     pyspacemouse.ButtonCallback(0, on_button),  # Button 0
@@ -175,7 +177,7 @@ with pyspacemouse.open(
 ) as device:
     while True:
         device.read()  # Triggers callbacks
-        time.sleep(0.001) # NOTE: avoid larger sleeps, which can cause data to buffer
+        time.sleep(0.001)  # NOTE: avoid larger sleeps, which can cause data to buffer
 ```
 
 ### Custom Axis Mapping

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -117,23 +117,25 @@ If you don't want to modify the library, use `create_device_info()`:
 ```python
 import pyspacemouse
 
-device_spec = pyspacemouse.create_device_info({
-    "name": "MyCustomDevice",
-    "hid_id": [0x256F, 0xC652],
-    "axis_scale": 350.0,
-    "mappings": {
-        "x": [1, 1, 2, 1],
-        "y": [1, 3, 4, -1],
-        "z": [1, 5, 6, -1],
-        "pitch": [2, 1, 2, -1],
-        "roll": [2, 3, 4, -1],
-        "yaw": [2, 5, 6, 1],
-    },
-    "buttons": {
-        "LEFT": [3, 1, 0],
-        "RIGHT": [3, 1, 1],
-    },
-})
+device_spec = pyspacemouse.create_device_info(
+    {
+        "name": "MyCustomDevice",
+        "hid_id": [0x256F, 0xC652],
+        "axis_scale": 350.0,
+        "mappings": {
+            "x": [1, 1, 2, 1],
+            "y": [1, 3, 4, -1],
+            "z": [1, 5, 6, -1],
+            "pitch": [2, 1, 2, -1],
+            "roll": [2, 3, 4, -1],
+            "yaw": [2, 5, 6, 1],
+        },
+        "buttons": {
+            "LEFT": [3, 1, 0],
+            "RIGHT": [3, 1, 1],
+        },
+    }
+)
 
 with pyspacemouse.open(device_spec=device_spec) as device:
     state = device.read()

--- a/docs/README.md
+++ b/docs/README.md
@@ -110,7 +110,7 @@ with pyspacemouse.open() as device:
     state = device.read()
 
     # 6-DOF axes (range: -1.0 to 1.0)
-    print(state.x, state.y, state.z)       # Translation
+    print(state.x, state.y, state.z)  # Translation
     print(state.roll, state.pitch, state.yaw)  # Rotation
 
     # Buttons (list of 0/1)
@@ -149,9 +149,11 @@ mapping table. Custom
 import pyspacemouse
 import time
 
+
 # Button callback
 def on_button(state, buttons, pressed):
     print(f"Button {pressed} pressed!")
+
 
 button_callbacks = [
     pyspacemouse.ButtonCallback(0, on_button),  # Button 0
@@ -175,7 +177,7 @@ with pyspacemouse.open(
 ) as device:
     while True:
         device.read()  # Triggers callbacks
-        time.sleep(0.001) # NOTE: avoid larger sleeps, which can cause data to buffer
+        time.sleep(0.001)  # NOTE: avoid larger sleeps, which can cause data to buffer
 ```
 
 ### Custom Axis Mapping

--- a/docs/mouseApi/examples.md
+++ b/docs/mouseApi/examples.md
@@ -7,7 +7,7 @@
 - Run: `python examples/01_basic.py`
 
 ```py title="examples/01_basic.py"
---8<-- "examples/01_basic.py"
+--8 < --"examples/01_basic.py"
 ```
 
 ## 02. Callbacks
@@ -17,7 +17,7 @@
 - Run: `python examples/02_callbacks.py`
 
 ```py title="examples/02_callbacks.py"
---8<-- "examples/02_callbacks.py"
+--8 < --"examples/02_callbacks.py"
 ```
 
 ## 03. Multi Device
@@ -27,7 +27,7 @@
 - Run: `python examples/03_multi_device.py`
 
 ```py title="examples/03_multi_device.py"
---8<-- "examples/03_multi_device.py"
+--8 < --"examples/03_multi_device.py"
 ```
 
 ## 04. Open By Path
@@ -37,7 +37,7 @@
 - Run: `python examples/04_open_by_path.py`
 
 ```py title="examples/04_open_by_path.py"
---8<-- "examples/04_open_by_path.py"
+--8 < --"examples/04_open_by_path.py"
 ```
 
 ## 05. Discovery
@@ -47,7 +47,7 @@
 - Run: `python examples/05_discovery.py`
 
 ```py title="examples/05_discovery.py"
---8<-- "examples/05_discovery.py"
+--8 < --"examples/05_discovery.py"
 ```
 
 ## 06. Axis Callbacks
@@ -57,7 +57,7 @@
 - Run: `python examples/06_axis_callbacks.py`
 
 ```py title="examples/06_axis_callbacks.py"
---8<-- "examples/06_axis_callbacks.py"
+--8 < --"examples/06_axis_callbacks.py"
 ```
 
 ## 07. Led
@@ -67,7 +67,7 @@
 - Run: `python examples/07_led.py`
 
 ```py title="examples/07_led.py"
---8<-- "examples/07_led.py"
+--8 < --"examples/07_led.py"
 ```
 
 ## 08. Buttons
@@ -77,7 +77,7 @@
 - Run: `python examples/08_buttons.py`
 
 ```py title="examples/08_buttons.py"
---8<-- "examples/08_buttons.py"
+--8 < --"examples/08_buttons.py"
 ```
 
 ## 09. Invert Rotations
@@ -87,7 +87,7 @@
 - Run: `python examples/09_invert_rotations.py`
 
 ```py title="examples/09_invert_rotations.py"
---8<-- "examples/09_invert_rotations.py"
+--8 < --"examples/09_invert_rotations.py"
 ```
 
 ## 10. Custom Config Unity
@@ -97,5 +97,5 @@
 - Run: `python examples/10_custom_config_unity.py`
 
 ```py title="examples/10_custom_config_unity.py"
---8<-- "examples/10_custom_config_unity.py"
+--8 < --"examples/10_custom_config_unity.py"
 ```

--- a/docs/mouseApi/index.md
+++ b/docs/mouseApi/index.md
@@ -101,8 +101,8 @@ custom = pyspacemouse.create_device_info(
     vendor_id=0x256F,
     product_id=0xC635,
     mappings={
-        "x": (1, 1, 2, 1),      # (channel, byte1, byte2, scale)
-        "y": (1, 3, 4, -1),     # Inverted
+        "x": (1, 1, 2, 1),  # (channel, byte1, byte2, scale)
+        "y": (1, 3, 4, -1),  # Inverted
         "z": (1, 5, 6, -1),
         "pitch": (2, 1, 2, -1),
         "roll": (2, 3, 4, -1),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Operating System :: OS Independent",
     "Topic :: System :: Hardware :: Universal Serial Bus (USB) :: Human Interface Device (HID)",
 ]

--- a/pyspacemouse/callbacks.py
+++ b/pyspacemouse/callbacks.py
@@ -6,6 +6,7 @@ for handling SpaceMouse events.
 
 from __future__ import annotations
 
+import sys
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Callable, List, Optional, Sequence, Union
 
@@ -18,8 +19,10 @@ ButtonChangeCallback = Callable[["SpaceMouseState", List[int]], None]
 ButtonPressCallback = Callable[["SpaceMouseState", List[int], Union[int, List[int]]], None]
 DofValueCallback = Callable[["SpaceMouseState", float], None]
 
+_DATACLASS_SLOTS = {"slots": True} if sys.version_info >= (3, 10) else {}
 
-@dataclass(slots=True)
+
+@dataclass(**_DATACLASS_SLOTS)
 class ButtonCallback:
     """Callback triggered when specific button(s) are pressed.
 
@@ -42,7 +45,7 @@ class ButtonCallback:
             raise TypeError("buttons must be int or list of int")
 
 
-@dataclass(slots=True)
+@dataclass(**_DATACLASS_SLOTS)
 class DofCallback:
     """Callback triggered when a specific axis changes.
 
@@ -71,7 +74,7 @@ class DofCallback:
             raise TypeError("callback_minus must be callable or None")
 
 
-@dataclass(slots=True)
+@dataclass(**_DATACLASS_SLOTS)
 class Config:
     """Configuration container for all callback types.
 

--- a/pyspacemouse/types.py
+++ b/pyspacemouse/types.py
@@ -6,6 +6,7 @@ All types are immutable (frozen dataclasses) for thread safety and clarity.
 
 from __future__ import annotations
 
+import sys
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Literal
@@ -15,6 +16,8 @@ Axis = Literal["x", "y", "z", "roll", "pitch", "yaw"]
 
 # All valid axis names
 AXIS_NAMES: tuple[Axis, ...] = ("x", "y", "z", "roll", "pitch", "yaw")
+
+_DATACLASS_SLOTS = {"slots": True} if sys.version_info >= (3, 10) else {}
 
 
 class AxisConvention(str, Enum):
@@ -53,7 +56,7 @@ class AxisConvention(str, Enum):
     UNITY = "unity"
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, **_DATACLASS_SLOTS)
 class AxisSpec:
     """Specification for reading an axis value from HID data.
 
@@ -70,7 +73,7 @@ class AxisSpec:
     scale: int
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, **_DATACLASS_SLOTS)
 class ButtonSpec:
     """Specification for reading a button state from HID data.
 
@@ -96,7 +99,7 @@ class ButtonState(list):
         return sum((b << i) for (i, b) in enumerate(reversed(self)))
 
 
-@dataclass(slots=True)
+@dataclass(**_DATACLASS_SLOTS)
 class SpaceMouseState:
     """Current state of the SpaceMouse device.
 
@@ -132,7 +135,7 @@ class SpaceMouseState:
         return any(abs(getattr(self, axis)) > threshold for axis in AXIS_NAMES)
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, **_DATACLASS_SLOTS)
 class DeviceInfo:
     """Static information about a device type.
 

--- a/tests/test_axis_conventions.py
+++ b/tests/test_axis_conventions.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from pyspacemouse.config_helpers import apply_axis_convention
+from pyspacemouse.types import AXIS_NAMES, AxisConvention, AxisSpec, DeviceInfo
+
+
+def _hid_spec() -> DeviceInfo:
+    mappings = {
+        axis: AxisSpec(channel=index, byte1=index * 2, byte2=index * 2 + 1, scale=index + 1)
+        for index, axis in enumerate(AXIS_NAMES, start=1)
+    }
+    return DeviceInfo(
+        name="Test HID device",
+        vendor_id=1,
+        product_id=2,
+        led_id=None,
+        axis_scale=350.0,
+        mappings=mappings,
+        button_specs=(),
+        button_names=(),
+        convention=AxisConvention.HID,
+    )
+
+
+def test_each_axis_convention_round_trips_through_hid() -> None:
+    hid_spec = _hid_spec()
+
+    for convention in AxisConvention:
+        converted = apply_axis_convention(hid_spec, convention)
+        round_tripped = apply_axis_convention(converted, AxisConvention.HID)
+
+        assert round_tripped.convention == AxisConvention.HID
+        assert round_tripped.mappings == hid_spec.mappings
+
+
+def test_axis_conventions_round_trip_between_non_hid_frames() -> None:
+    hid_z_up_spec = apply_axis_convention(_hid_spec(), AxisConvention.HID_Z_UP)
+
+    ros_spec = apply_axis_convention(hid_z_up_spec, AxisConvention.ROS)
+    round_tripped = apply_axis_convention(ros_spec, AxisConvention.HID_Z_UP)
+
+    assert round_tripped.convention == AxisConvention.HID_Z_UP
+    assert round_tripped.mappings == hid_z_up_spec.mappings

--- a/tests/test_axis_conventions.py
+++ b/tests/test_axis_conventions.py
@@ -30,7 +30,14 @@ def test_each_axis_convention_round_trips_through_hid() -> None:
         round_tripped = apply_axis_convention(converted, AxisConvention.HID)
 
         assert round_tripped.convention == AxisConvention.HID
-        assert round_tripped.mappings == hid_spec.mappings
+        # Full equality so a round trip can't quietly drop an unrelated field
+        assert round_tripped == hid_spec
+
+
+def test_applying_the_current_convention_returns_the_same_spec() -> None:
+    hid_spec = _hid_spec()
+
+    assert apply_axis_convention(hid_spec, AxisConvention.HID) is hid_spec
 
 
 def test_axis_conventions_round_trip_between_non_hid_frames() -> None:
@@ -40,4 +47,4 @@ def test_axis_conventions_round_trip_between_non_hid_frames() -> None:
     round_tripped = apply_axis_convention(ros_spec, AxisConvention.HID_Z_UP)
 
     assert round_tripped.convention == AxisConvention.HID_Z_UP
-    assert round_tripped.mappings == hid_z_up_spec.mappings
+    assert round_tripped == hid_z_up_spec


### PR DESCRIPTION
Add tests that round-trip every `AxisConvention` through HID and verify mappings are preserved

Add a small dataclass `slots=True` compatibility shim so the package imports on Python 3.8/3.9 during CI

Also added Python 3.14 as well

Meant to be considered after #52

## Summary by Sourcery

Add CI axis convention tests and extend Python version support while maintaining dataclass slots compatibility on older interpreters.

Enhancements:
- Introduce a conditional dataclass slots shim to keep types and callbacks slot-based on Python 3.10+ while remaining compatible with Python 3.8 and 3.9.

Build:
- Declare Python 3.14 support in project metadata classifiers.

CI:
- Add a CI test job running axis convention tests across Python 3.8–3.14 with required HID system dependencies.

Tests:
- Add tests verifying all axis conventions round-trip correctly through HID mappings, including non-HID frame conversions.