### PR TITLE
Swap easyhid for hid for macOS compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 3Dconnexion Space Mouse in Python using raw HID.
 Note: you **don't** need to install or use any of the drivers or 3Dconnexion software to use this package.
-It interfaces with the controller directly with `hidapi` and python wrapper library `easyhid`.
+It interfaces with the controller directly with `hidapi` and python wrapper library `hid`.
 
 <p align="center">
 <a href="https://hit.kubaandrysek.cz/?url=https%3A%2F%2Fgithub.com%2FJakubAndrysek%2Fpyspacemouse&chart=true"><img src="https://hit.kubaandrysek.cz/?url=https%3A%2F%2Fgithub.com%2FJakubAndrysek%2Fpyspacemouse"/></a>
@@ -251,12 +251,6 @@ See the [examples/](https://github.com/JakubAndrysek/PySpaceMouse/tree/master/ex
 echo 'KERNEL=="hidraw*", SUBSYSTEM=="hidraw", MODE="0664", GROUP="plugdev"' | sudo tee /etc/udev/rules.d/99-hidraw-permissions.rules
 sudo usermod -aG plugdev $USER
 newgrp plugdev
-```
-
-### macOS PATH
-
-```bash
-export DYLD_LIBRARY_PATH=/opt/homebrew/Cellar/hidapi/<VERSION>/lib:$DYLD_LIBRARY_PATH
 ```
 
 ## Troubleshooting

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@
 
 3Dconnexion Space Mouse in Python using raw HID.
 Note: you **don't** need to install or use any of the drivers or 3Dconnexion software to use this package.
-It interfaces with the controller directly with `hidapi` and python wrapper library `easyhid`.
+It interfaces with the controller directly with `hidapi` and python wrapper library `hid`.
 
 <p align="center">
 <a href="https://hit.kubaandrysek.cz/?url=https%3A%2F%2Fgithub.com%2FJakubAndrysek%2Fpyspacemouse&chart=true"><img src="https://hit.kubaandrysek.cz/?url=https%3A%2F%2Fgithub.com%2FJakubAndrysek%2Fpyspacemouse"/></a>
@@ -251,12 +251,6 @@ See the [examples/](https://github.com/JakubAndrysek/PySpaceMouse/tree/master/ex
 echo 'KERNEL=="hidraw*", SUBSYSTEM=="hidraw", MODE="0664", GROUP="plugdev"' | sudo tee /etc/udev/rules.d/99-hidraw-permissions.rules
 sudo usermod -aG plugdev $USER
 newgrp plugdev
-```
-
-### macOS PATH
-
-```bash
-export DYLD_LIBRARY_PATH=/opt/homebrew/Cellar/hidapi/<VERSION>/lib:$DYLD_LIBRARY_PATH
 ```
 
 ## Troubleshooting

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -42,11 +42,11 @@ See [Custom Device Configuration](https://spacemouse.kubaandrysek.cz/mouseApi#cu
 
 ## Common issues
 
-### ModuleNotFoundError: No module named 'easyhid'
+### ModuleNotFoundError: No module named 'hid'
 
-- Install `easyhid` by `pip install easyhid`.
+- Install `hid` by `pip install hid`.
 
-### AttributeError: function/symbol 'hid_enumerate' not found in library '<None>': python3: undefined symbol: hid_enumerate
+### ImportError: hidapi C library not found / Unable to load any of the following libraries
 
 - HID C library is not installed or not found in PATH.
 - Follow the instructions in [requirements](./README.md#dependencies).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ classifiers = [
     "Operating System :: OS Independent",
     "Topic :: System :: Hardware :: Universal Serial Bus (USB) :: Human Interface Device (HID)",
 ]
-dependencies = ["easyhid", "tomli; python_version < '3.11'"]
+dependencies = ["hid", "tomli; python_version < '3.11'"]
 
 [project.urls]
 Documentation = "https://spacemouse.kubaandrysek.cz"

--- a/pyspacemouse/api.py
+++ b/pyspacemouse/api.py
@@ -20,13 +20,32 @@ import warnings
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Sequence, Tuple
 
-from easyhid import Enumeration
-
 from .callbacks import ButtonCallback, Config, DofCallback
 from .config_helpers import apply_axis_convention
 from .device import SpaceMouseDevice
 from .loader import get_device_specs
 from .types import AxisConvention, DeviceInfo, SpaceMouseState
+
+
+def _import_hid():
+    """Lazily import the `hid` package.
+
+    Deferred so that hardware-free parts of pyspacemouse (types, config
+    helpers, etc.) remain usable even when the native hidapi library isn't
+    installed.
+    """
+    try:
+        import hid
+    except ImportError as e:
+        raise ImportError(
+            "hidapi C library not found. Install it via your OS package manager "
+            "(e.g. `apt install libhidapi-hidraw0` on Debian/Ubuntu, `brew install "
+            "hidapi` on macOS, or download from "
+            "https://github.com/libusb/hidapi/releases on Windows) and make sure "
+            "the `hid` Python package is installed (`pip install hid`). See "
+            "https://spacemouse.kubaandrysek.cz for details."
+        ) from e
+    return hid
 
 
 def get_connected_devices() -> List[str]:
@@ -37,21 +56,18 @@ def get_connected_devices() -> List[str]:
         Empty list if no supported devices are found.
 
     Raises:
-        RuntimeError: If HID API is not installed.
+        ImportError: If the hidapi C library is not installed.
     """
-    try:
-        hid = Enumeration()
-    except AttributeError as e:
-        raise RuntimeError(
-            "HID API is probably not installed. See https://spacemouse.kubaandrysek.cz for details."
-        ) from e
-
+    hid = _import_hid()
     device_specs = get_device_specs()
     devices = []
 
-    for hid_device in hid.find():
+    for hid_device in hid.enumerate():
         for name, spec in device_specs.items():
-            if hid_device.vendor_id == spec.vendor_id and hid_device.product_id == spec.product_id:
+            if (
+                hid_device["vendor_id"] == spec.vendor_id
+                and hid_device["product_id"] == spec.product_id
+            ):
                 devices.append(name)
 
     return devices
@@ -73,23 +89,17 @@ def get_all_hid_devices() -> List[Tuple[str, str, int, int]]:
         List of tuples: (product_string, manufacturer_string, vendor_id, product_id)
 
     Raises:
-        RuntimeError: If HID API is not installed.
+        ImportError: If the hidapi C library is not installed.
     """
-    try:
-        hid = Enumeration()
-    except AttributeError as e:
-        raise RuntimeError(
-            "HID API is probably not installed. See https://spacemouse.kubaandrysek.cz for details."
-        ) from e
-
+    hid = _import_hid()
     return [
         (
-            dev.product_string or "",
-            dev.manufacturer_string or "",
-            dev.vendor_id,
-            dev.product_id,
+            dev["product_string"] or "",
+            dev["manufacturer_string"] or "",
+            dev["vendor_id"],
+            dev["product_id"],
         )
-        for dev in hid.find()
+        for dev in hid.enumerate()
     ]
 
 
@@ -130,7 +140,7 @@ def _create_and_open_device(
             )
         spec = apply_axis_convention(spec, axis_convention)
 
-    mouse = SpaceMouseDevice(info=spec, device=hid_device)
+    mouse = SpaceMouseDevice(info=spec, device=hid_device, nonblocking=nonblocking)
     mouse.configure(
         callback=callback,
         dof_callback=dof_callback,
@@ -139,7 +149,6 @@ def _create_and_open_device(
         button_callbacks=button_callbacks,
     )
     mouse.open()
-    hid_device.set_nonblocking(nonblocking)
     return mouse
 
 
@@ -185,7 +194,9 @@ def open_by_path(
         FileNotFoundError: If the specified path does not exist
         ValueError: If the device at path is not a supported SpaceMouse
                     (unless device_spec is provided)
+        ImportError: If the hidapi C library is not installed.
     """
+    hid = _import_hid()
     path = Path(path)
 
     if not path.exists():
@@ -195,11 +206,10 @@ def open_by_path(
     path = path.resolve()
 
     # Find the HID device at this path
-    hid = Enumeration()
     hid_device = None
 
-    for dev in hid.device_list:
-        dev_path = Path(dev.path).resolve()
+    for dev in hid.enumerate():
+        dev_path = Path(dev["path"].decode()).resolve()
         if dev_path == path:
             hid_device = dev
             break
@@ -217,16 +227,16 @@ def open_by_path(
 
         for device_s in all_specs.values():
             if (
-                hid_device.vendor_id == device_s.vendor_id
-                and hid_device.product_id == device_s.product_id
+                hid_device["vendor_id"] == device_s.vendor_id
+                and hid_device["product_id"] == device_s.product_id
             ):
                 spec = device_s
                 break
 
         if spec is None:
             raise ValueError(
-                f"Device at '{path}' (VID={hid_device.vendor_id:#06x}, "
-                f"PID={hid_device.product_id:#06x}) is not a supported SpaceMouse. "
+                f"Device at '{path}' (VID={hid_device['vendor_id']:#06x}, "
+                f"PID={hid_device['product_id']:#06x}) is not a supported SpaceMouse. "
                 f"Use device_spec parameter for custom/unsupported devices."
             )
 
@@ -294,7 +304,9 @@ def open(
     Raises:
         RuntimeError: If no device is found
         ValueError: If the specified device name is not recognized
+        ImportError: If the hidapi C library is not installed.
     """
+    hid = _import_hid()
     device_specs = get_device_specs()
 
     # Auto-detect device if not specified
@@ -312,11 +324,10 @@ def open(
     spec = device_spec if is_custom_spec else device_specs[device]
 
     # Find matching HID devices
-    hid = Enumeration()
     found = []
 
-    for hid_dev in hid.find():
-        if hid_dev.vendor_id == spec.vendor_id and hid_dev.product_id == spec.product_id:
+    for hid_dev in hid.enumerate():
+        if hid_dev["vendor_id"] == spec.vendor_id and hid_dev["product_id"] == spec.product_id:
             found.append(hid_dev)
 
     if not found:
@@ -382,23 +393,20 @@ def get_connected_devices_by_path() -> Dict[str, str]:
         Dict of paths: device names (e.g., {"/dev/hidraw0": "SpaceMouse Pro"}).
 
     Raises:
-        RuntimeError: If HID API is not installed.
+        ImportError: If the hidapi C library is not installed.
     """
-    try:
-        hid = Enumeration()
-    except AttributeError as e:
-        raise RuntimeError(
-            "HID API is probably not installed. See https://spacemouse.kubaandrysek.cz for details."
-        ) from e
-
+    hid = _import_hid()
     device_specs = get_device_specs()
     devices_by_path = {}
 
-    # hid.find() is all connected HID devices,
+    # hid.enumerate() is all connected HID devices,
     # device_specs is all supported Spacemouse devices.
-    for hid_device in hid.find():
+    for hid_device in hid.enumerate():
         for name, spec in device_specs.items():
-            if hid_device.vendor_id == spec.vendor_id and hid_device.product_id == spec.product_id:
-                devices_by_path[hid_device.path] = name
+            if (
+                hid_device["vendor_id"] == spec.vendor_id
+                and hid_device["product_id"] == spec.product_id
+            ):
+                devices_by_path[hid_device["path"].decode()] = name
 
     return devices_by_path

--- a/pyspacemouse/api.py
+++ b/pyspacemouse/api.py
@@ -16,6 +16,7 @@ Usage:
 
 from __future__ import annotations
 
+import os
 import warnings
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Sequence, Tuple
@@ -62,11 +63,11 @@ def get_connected_devices() -> List[str]:
     device_specs = get_device_specs()
     devices = []
 
-    for hid_device in hid.enumerate():
+    for hid_info in hid.enumerate():
         for name, spec in device_specs.items():
             if (
-                hid_device["vendor_id"] == spec.vendor_id
-                and hid_device["product_id"] == spec.product_id
+                hid_info["vendor_id"] == spec.vendor_id
+                and hid_info["product_id"] == spec.product_id
             ):
                 devices.append(name)
 
@@ -94,18 +95,18 @@ def get_all_hid_devices() -> List[Tuple[str, str, int, int]]:
     hid = _import_hid()
     return [
         (
-            dev["product_string"] or "",
-            dev["manufacturer_string"] or "",
-            dev["vendor_id"],
-            dev["product_id"],
+            hid_info["product_string"] or "",
+            hid_info["manufacturer_string"] or "",
+            hid_info["vendor_id"],
+            hid_info["product_id"],
         )
-        for dev in hid.enumerate()
+        for hid_info in hid.enumerate()
     ]
 
 
 def _create_and_open_device(
     spec: DeviceInfo,
-    hid_device,
+    hid_info,
     callback: Optional[Callable[[SpaceMouseState], None]] = None,
     dof_callback: Optional[Callable[[SpaceMouseState], None]] = None,
     dof_callbacks: Optional[Sequence[DofCallback]] = None,
@@ -140,7 +141,7 @@ def _create_and_open_device(
             )
         spec = apply_axis_convention(spec, axis_convention)
 
-    mouse = SpaceMouseDevice(info=spec, device=hid_device, nonblocking=nonblocking)
+    mouse = SpaceMouseDevice(info=spec, hid_info=hid_info, nonblocking=nonblocking)
     mouse.configure(
         callback=callback,
         dof_callback=dof_callback,
@@ -206,15 +207,15 @@ def open_by_path(
     path = path.resolve()
 
     # Find the HID device at this path
-    hid_device = None
+    hid_info = None
 
-    for dev in hid.enumerate():
-        dev_path = Path(dev["path"].decode()).resolve()
-        if dev_path == path:
-            hid_device = dev
+    for candidate in hid.enumerate():
+        candidate_path = Path(os.fsdecode(candidate["path"])).resolve()
+        if candidate_path == path:
+            hid_info = candidate
             break
 
-    if hid_device is None:
+    if hid_info is None:
         raise FileNotFoundError(f"No HID device found at path '{path}'.")
 
     # Use provided spec or find matching device specification
@@ -227,16 +228,16 @@ def open_by_path(
 
         for device_s in all_specs.values():
             if (
-                hid_device["vendor_id"] == device_s.vendor_id
-                and hid_device["product_id"] == device_s.product_id
+                hid_info["vendor_id"] == device_s.vendor_id
+                and hid_info["product_id"] == device_s.product_id
             ):
                 spec = device_s
                 break
 
         if spec is None:
             raise ValueError(
-                f"Device at '{path}' (VID={hid_device['vendor_id']:#06x}, "
-                f"PID={hid_device['product_id']:#06x}) is not a supported SpaceMouse. "
+                f"Device at '{path}' (VID={hid_info['vendor_id']:#06x}, "
+                f"PID={hid_info['product_id']:#06x}) is not a supported SpaceMouse. "
                 f"Use device_spec parameter for custom/unsupported devices."
             )
 
@@ -244,7 +245,7 @@ def open_by_path(
 
     return _create_and_open_device(
         spec=spec,
-        hid_device=hid_device,
+        hid_info=hid_info,
         callback=callback,
         dof_callback=dof_callback,
         dof_callbacks=dof_callbacks,
@@ -326,9 +327,9 @@ def open(
     # Find matching HID devices
     found = []
 
-    for hid_dev in hid.enumerate():
-        if hid_dev["vendor_id"] == spec.vendor_id and hid_dev["product_id"] == spec.product_id:
-            found.append(hid_dev)
+    for hid_info in hid.enumerate():
+        if hid_info["vendor_id"] == spec.vendor_id and hid_info["product_id"] == spec.product_id:
+            found.append(hid_info)
 
     if not found:
         raise RuntimeError(f"Device '{device}' not found.")
@@ -337,12 +338,12 @@ def open(
     if device_index >= len(found):
         device_index = 0
 
-    hid_dev = found[device_index]
+    hid_info = found[device_index]
     print(f"{device} found")
 
     return _create_and_open_device(
         spec=spec,
-        hid_device=hid_dev,
+        hid_info=hid_info,
         callback=callback,
         dof_callback=dof_callback,
         dof_callbacks=dof_callbacks,
@@ -401,12 +402,12 @@ def get_connected_devices_by_path() -> Dict[str, str]:
 
     # hid.enumerate() is all connected HID devices,
     # device_specs is all supported Spacemouse devices.
-    for hid_device in hid.enumerate():
+    for hid_info in hid.enumerate():
         for name, spec in device_specs.items():
             if (
-                hid_device["vendor_id"] == spec.vendor_id
-                and hid_device["product_id"] == spec.product_id
+                hid_info["vendor_id"] == spec.vendor_id
+                and hid_info["product_id"] == spec.product_id
             ):
-                devices_by_path[hid_device["path"].decode()] = name
+                devices_by_path[os.fsdecode(hid_info["path"])] = name
 
     return devices_by_path

--- a/pyspacemouse/device.py
+++ b/pyspacemouse/device.py
@@ -13,13 +13,15 @@ Supports context manager protocol for safe resource cleanup:
 from __future__ import annotations
 
 import timeit
-from typing import TYPE_CHECKING, Callable, List, Optional, Sequence
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Sequence
 
 from .callbacks import ButtonCallback, Config, DofCallback
 from .types import AXIS_NAMES, ButtonState, DeviceInfo, SpaceMouseState
 
 if TYPE_CHECKING:
     from hid import Device as HIDDevice
+
+    HIDInfo = Dict[str, Any]
 
 # High-accuracy clock for timing
 high_acc_clock = timeit.default_timer
@@ -51,7 +53,7 @@ class SpaceMouseDevice:
 
     __slots__ = (
         "_info",
-        "_device_info",
+        "_hid_info",
         "_device",
         "_state",
         "_last_axis_time",
@@ -68,18 +70,21 @@ class SpaceMouseDevice:
     )
 
     def __init__(
-        self, info: DeviceInfo, device: Optional[dict] = None, nonblocking: bool = True
+        self,
+        info: DeviceInfo,
+        hid_info: Optional[HIDInfo] = None,
+        nonblocking: bool = True,
     ) -> None:
         """Initialize the SpaceMouseDevice.
 
         Args:
             info: Device specification from loader
-            device: Optional HID device metadata dict (from hid.enumerate()),
-                    used to open the connection
+            hid_info: Optional HID device metadata dict (from hid.enumerate()),
+                      used to open the connection
             nonblocking: If True, reads are non-blocking once opened
         """
         self._info = info
-        self._device_info = device
+        self._hid_info = hid_info
         self._device: Optional[HIDDevice] = None
 
         # Initialize state
@@ -171,13 +176,15 @@ class SpaceMouseDevice:
 
     def open(self) -> None:
         """Open the connection to the device."""
-        if self._device_info is None:
+        if self._hid_info is None:
             raise RuntimeError("No HID device assigned to this SpaceMouseDevice")
 
-        import hid
+        from .api import _import_hid
+
+        hid = _import_hid()
 
         try:
-            self._device = hid.Device(path=self._device_info["path"])
+            self._device = hid.Device(path=self._hid_info["path"])
         except hid.HIDException as e:
             raise RuntimeError("Failed to open device") from e
 
@@ -186,7 +193,7 @@ class SpaceMouseDevice:
         # Copy product details
         self._product_name = self._device.product or ""
         self._vendor_name = self._device.manufacturer or ""
-        self._version_number = str(self._device_info.get("release_number") or "")
+        self._version_number = str(self._hid_info.get("release_number") or "")
 
         # Convert serial number to hex
         serial = self._device.serial or ""

--- a/pyspacemouse/device.py
+++ b/pyspacemouse/device.py
@@ -15,13 +15,11 @@ from __future__ import annotations
 import timeit
 from typing import TYPE_CHECKING, Callable, List, Optional, Sequence
 
-from easyhid import HIDException
-
 from .callbacks import ButtonCallback, Config, DofCallback
 from .types import AXIS_NAMES, ButtonState, DeviceInfo, SpaceMouseState
 
 if TYPE_CHECKING:
-    from easyhid import Device as HIDDevice
+    from hid import Device as HIDDevice
 
 # High-accuracy clock for timing
 high_acc_clock = timeit.default_timer
@@ -53,6 +51,7 @@ class SpaceMouseDevice:
 
     __slots__ = (
         "_info",
+        "_device_info",
         "_device",
         "_state",
         "_last_axis_time",
@@ -68,15 +67,20 @@ class SpaceMouseDevice:
         "_serial_number",
     )
 
-    def __init__(self, info: DeviceInfo, device: Optional[HIDDevice] = None) -> None:
+    def __init__(
+        self, info: DeviceInfo, device: Optional[dict] = None, nonblocking: bool = True
+    ) -> None:
         """Initialize the SpaceMouseDevice.
 
         Args:
             info: Device specification from loader
-            device: Optional HID device instance
+            device: Optional HID device metadata dict (from hid.enumerate()),
+                    used to open the connection
+            nonblocking: If True, reads are non-blocking once opened
         """
         self._info = info
-        self._device = device
+        self._device_info = device
+        self._device: Optional[HIDDevice] = None
 
         # Initialize state
         self._state = SpaceMouseState(buttons=ButtonState([0] * len(info.button_specs)))
@@ -88,7 +92,7 @@ class SpaceMouseDevice:
         self._dof_callbacks: Optional[Sequence[DofCallback]] = None
         self._button_callback: Optional[Callable[[SpaceMouseState, List[int]], None]] = None
         self._button_callbacks: Optional[Sequence[ButtonCallback]] = None
-        self._nonblocking = True
+        self._nonblocking = nonblocking
 
         # Connection details (populated on open)
         self._product_name: str = ""
@@ -167,21 +171,25 @@ class SpaceMouseDevice:
 
     def open(self) -> None:
         """Open the connection to the device."""
-        if self._device is None:
+        if self._device_info is None:
             raise RuntimeError("No HID device assigned to this SpaceMouseDevice")
 
+        import hid
+
         try:
-            self._device.open()
-        except HIDException as e:
+            self._device = hid.Device(path=self._device_info["path"])
+        except hid.HIDException as e:
             raise RuntimeError("Failed to open device") from e
 
+        self._device.nonblocking = self._nonblocking
+
         # Copy product details
-        self._product_name = self._device.product_string or ""
-        self._vendor_name = self._device.manufacturer_string or ""
-        self._version_number = str(self._device.release_number or "")
+        self._product_name = self._device.product or ""
+        self._vendor_name = self._device.manufacturer or ""
+        self._version_number = str(self._device_info.get("release_number") or "")
 
         # Convert serial number to hex
-        serial = self._device.serial_number or ""
+        serial = self._device.serial or ""
         self._serial_number = "".join(f"{ord(c):02X}" for c in serial)
 
     def close(self) -> None:
@@ -304,7 +312,7 @@ class SpaceMouseDevice:
         report_id, on_value = self._info.led_id
         led_value = on_value if state else 0x00
         try:
-            self._device.write(bytearray([report_id, led_value]))
+            self._device.write(bytes([report_id, led_value]))
         except Exception:
             pass  # Silently fail if LED control not supported
 

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -33,11 +33,11 @@ See [Custom Device Configuration](https://spacemouse.kubaandrysek.cz/mouseApi#cu
 
 ## Common issues
 
-### ModuleNotFoundError: No module named 'easyhid'
+### ModuleNotFoundError: No module named 'hid'
 
-- Install `easyhid` by `pip install easyhid`.
+- Install `hid` by `pip install hid`.
 
-### AttributeError: function/symbol 'hid_enumerate' not found in library '<None>': python3: undefined symbol: hid_enumerate
+### ImportError: hidapi C library not found / Unable to load any of the following libraries
 
 - HID C library is not installed or not found in PATH.
 - Follow the instructions in [requirements](./README.md#dependencies).


### PR DESCRIPTION
easyhid's platform detection appears to have been broken by macOS changes for many years ahtn/python-easyhid#4 

This changeset swaps over to a lighter and presently-maintained hid wrapper.