### PR TITLE
Swap from easyhid to cython-hidapi

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,15 +62,6 @@ jobs:
     #         - uses: actions/setup-python@v5
     #           with:
     #               python-version: ${{ matrix.py }}
-    #         - name: Install system dependencies (Linux)
-    #           if: runner.os == 'Linux'
-    #           run: |
-    #               sudo apt-get update
-    #               sudo apt-get install -y libhidapi-dev
-    #         - name: Install system dependencies (macOS)
-    #           if: runner.os == 'macOS'
-    #           run: |
-    #               brew install hidapi
     #         - name: Install Hatch
     #           run: pip install hatch
     #         - name: Run tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,10 +21,10 @@ lsusb
 # VID = 256f, PID = c652
 ```
 
-**Using [hidapitester](https://github.com/todbot/hidapitester):**
+**Using pyspacemouse itself:**
 ```bash
-./hidapitester --list
-# Example: 046D/C626: 3Dconnexion - SpaceNavigator
+pyspacemouse --list-hid
+# Example: - SpaceMouse Compact by 3Dconnexion [VID: 0x256f, PID: 0xc635]
 ```
 
 ### 2. Analyze HID Data
@@ -42,6 +42,23 @@ Move the SpaceMouse knob in each direction and identify which bytes change:
 - **Channel 3**: Button data
 
 Each axis is typically a signed 16-bit value (2 bytes, little-endian).
+
+The report descriptor is useful when the layout isn't obvious from the input reports:
+
+```bash
+./hidapitester --vidpid <VID/PID> --open --get-report-descriptor
+```
+
+??? note "My output"
+    ```bash
+    ./hidapitester --vidpid 046D/C626 --open --get-report-descriptor
+    Opening device, vid/pid: 0x046D/0xC626
+    Report Descriptor:
+    05 01 09 08 A1 01 A1 00 85 01 16 A2 FE 26 5E 01 36 88 FA 46 78 05 55 0C 65 11 09 30 09 31 09 32
+    75 10 95 03 81 06 C0 A1 00 85 02 09 33 09 34 09 35 75 10 95 03 81 06 C0 A1 02 85 03 05 01 05 09
+    ...
+    Closing device
+    ```
 
 ### 3. Add Device to `devices.toml`
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,31 @@ It interfaces with the controller directly with `hidapi`, via the [`hidapi`](htt
 pip install pyspacemouse
 ```
 
+## CLI
+
+```bash
+pyspacemouse --list-connected    # Show connected devices
+pyspacemouse --list-supported    # Show all supported types
+pyspacemouse --list-hid          # Show all HID devices
+pyspacemouse --test              # Test connection
+pyspacemouse --version           # Show version
+```
+### Linux permissions
+
+On linux, you may not have permission to read from the device.
+To fix this, you can create a udev rule based on the device's Vendor ID (`256f` for 3Dconnexion's):
+
+```bash
+echo 'SUBSYSTEM=="hidraw", ATTRS{idVendor}=="256f", MODE="0660", TAG+="uaccess"' | sudo tee /etc/udev/rules.d/50-spacemouse.rules
+echo 'SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="256f", MODE="0660", TAG+="uaccess"' | sudo tee -a /etc/udev/rules.d/50-spacemouse.rules
+sudo udevadm control --reload-rules && sudo udevadm trigger
+```
+
+## Troubleshooting
+
+See [troubleshooting.md](./troubleshooting.md) for help with common issues.
+
+
 ## Quick Start
 
 Here we use `has_motion()` to check if any of the spatial axes have non-zero values.
@@ -212,15 +237,6 @@ with pyspacemouse.open(device_spec=custom) as device:
 
 See [Custom Device Configuration](./docs/mouseApi/index.md#custom-device-configuration) for full API.
 
-## CLI
-
-```bash
-pyspacemouse --list-connected    # Show connected devices
-pyspacemouse --list-supported    # Show all supported types
-pyspacemouse --list-hid          # Show all HID devices
-pyspacemouse --test              # Test connection
-pyspacemouse --version           # Show version
-```
 
 ## Examples
 
@@ -244,20 +260,6 @@ See the [examples/](https://github.com/JakubAndrysek/PySpaceMouse/tree/master/ex
 `pip install pyspacemouse` pulls in the [`hidapi`](https://pypi.org/project/hidapi/) package,
 whose wheels bundle the hidapi C library. There is nothing else to install on Linux, macOS
 or Windows.
-
-### Linux permissions
-
-Use `lsusb` to find your device's vendor ID (`256f` is 3Dconnexion's):
-
-```bash
-echo 'SUBSYSTEM=="hidraw", ATTRS{idVendor}=="256f", MODE="0660", TAG+="uaccess"' | sudo tee /etc/udev/rules.d/50-spacemouse.rules
-echo 'SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="256f", MODE="0660", TAG+="uaccess"' | sudo tee -a /etc/udev/rules.d/50-spacemouse.rules
-sudo udevadm control --reload-rules && sudo udevadm trigger
-```
-
-## Troubleshooting
-
-See [troubleshooting.md](./troubleshooting.md) for help with common issues.
 
 ## Developing / Contributing
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 3Dconnexion Space Mouse in Python using raw HID.
 Note: you **don't** need to install or use any of the drivers or 3Dconnexion software to use this package.
-It interfaces with the controller directly with `hidapi` and python wrapper library `easyhid`.
+It interfaces with the controller directly with `hidapi`, via the [`hidapi`](https://pypi.org/project/hidapi/) Python bindings.
 
 <p align="center">
 <a href="https://hit.kubaandrysek.cz/?url=https%3A%2F%2Fgithub.com%2FJakubAndrysek%2Fpyspacemouse&chart=true"><img src="https://hit.kubaandrysek.cz/?url=https%3A%2F%2Fgithub.com%2FJakubAndrysek%2Fpyspacemouse"/></a>
@@ -241,11 +241,9 @@ See the [examples/](https://github.com/JakubAndrysek/PySpaceMouse/tree/master/ex
 
 ## Dependencies
 
-### hidapi (C library)
-
-- **Linux**: `sudo apt-get install libhidapi-dev`
-- **macOS**: `brew install hidapi`
-- **Windows**: Download from [hidapi releases](https://github.com/libusb/hidapi/releases)
+`pip install pyspacemouse` pulls in the [`hidapi`](https://pypi.org/project/hidapi/) package,
+whose wheels bundle the hidapi C library. There is nothing else to install on Linux, macOS
+or Windows.
 
 ### Linux permissions
 
@@ -253,12 +251,6 @@ See the [examples/](https://github.com/JakubAndrysek/PySpaceMouse/tree/master/ex
 echo 'KERNEL=="hidraw*", SUBSYSTEM=="hidraw", MODE="0664", GROUP="plugdev"' | sudo tee /etc/udev/rules.d/99-hidraw-permissions.rules
 sudo usermod -aG plugdev $USER
 newgrp plugdev
-```
-
-### macOS PATH
-
-```bash
-export DYLD_LIBRARY_PATH=/opt/homebrew/Cellar/hidapi/<VERSION>/lib:$DYLD_LIBRARY_PATH
 ```
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -247,10 +247,14 @@ or Windows.
 
 ### Linux permissions
 
+Use `lsusb` to find your device's vendor ID (`256f` is 3Dconnexion's):
+
 ```bash
-echo 'KERNEL=="hidraw*", SUBSYSTEM=="hidraw", MODE="0664", GROUP="plugdev"' | sudo tee /etc/udev/rules.d/99-hidraw-permissions.rules
-sudo usermod -aG plugdev $USER
-newgrp plugdev
+echo 'SUBSYSTEM=="hidraw", ATTRS{idVendor}=="256f", MODE="0664", GROUP="input", TAG+="uaccess"' | sudo tee /etc/udev/rules.d/99-spacemouse.rules
+echo 'SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTR{idVendor}=="256f", MODE="0664", GROUP="input", TAG+="uaccess"' | sudo tee -a /etc/udev/rules.d/99-spacemouse.rules
+sudo udevadm control --reload-rules && sudo udevadm trigger
+sudo usermod -aG input $USER
+newgrp input
 ```
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -250,11 +250,9 @@ or Windows.
 Use `lsusb` to find your device's vendor ID (`256f` is 3Dconnexion's):
 
 ```bash
-echo 'SUBSYSTEM=="hidraw", ATTRS{idVendor}=="256f", MODE="0664", GROUP="input", TAG+="uaccess"' | sudo tee /etc/udev/rules.d/99-spacemouse.rules
-echo 'SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTR{idVendor}=="256f", MODE="0664", GROUP="input", TAG+="uaccess"' | sudo tee -a /etc/udev/rules.d/99-spacemouse.rules
+echo 'SUBSYSTEM=="hidraw", ATTRS{idVendor}=="256f", MODE="0660", TAG+="uaccess"' | sudo tee /etc/udev/rules.d/50-spacemouse.rules
+echo 'SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="256f", MODE="0660", TAG+="uaccess"' | sudo tee -a /etc/udev/rules.d/50-spacemouse.rules
 sudo udevadm control --reload-rules && sudo udevadm trigger
-sudo usermod -aG input $USER
-newgrp input
 ```
 
 ## Troubleshooting

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -27,17 +27,6 @@ pyspacemouse --list-hid
 # Example: - SpaceMouse Compact by 3Dconnexion [VID: 0x256f, PID: 0xc635]
 ```
 
-**Using [hidapitester](https://github.com/todbot/hidapitester):**
-```bash
-./hidapitester --list
-# Example: 046D/C626: 3Dconnexion - SpaceNavigator
-```
-
-Note that hidapitester links its own copy of hidapi, while pyspacemouse uses the one bundled
-in the `hidapi` wheel - and on Linux it uses the `hidraw` backend rather than libusb. The
-two can therefore report devices differently; `pyspacemouse --list-hid` is what the library
-actually sees.
-
 ### 2. Analyze HID Data
 
 Use `hidapitester` to read raw data from your device:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -21,11 +21,22 @@ lsusb
 # VID = 256f, PID = c652
 ```
 
+**Using pyspacemouse itself:**
+```bash
+pyspacemouse --list-hid
+# Example: - SpaceMouse Compact by 3Dconnexion [VID: 0x256f, PID: 0xc635]
+```
+
 **Using [hidapitester](https://github.com/todbot/hidapitester):**
 ```bash
 ./hidapitester --list
 # Example: 046D/C626: 3Dconnexion - SpaceNavigator
 ```
+
+Note that hidapitester links its own copy of hidapi, while pyspacemouse uses the one bundled
+in the `hidapi` wheel - and on Linux it uses the `hidraw` backend rather than libusb. The
+two can therefore report devices differently; `pyspacemouse --list-hid` is what the library
+actually sees.
 
 ### 2. Analyze HID Data
 
@@ -42,6 +53,23 @@ Move the SpaceMouse knob in each direction and identify which bytes change:
 - **Channel 3**: Button data
 
 Each axis is typically a signed 16-bit value (2 bytes, little-endian).
+
+The report descriptor is useful when the layout isn't obvious from the input reports:
+
+```bash
+./hidapitester --vidpid <VID/PID> --open --get-report-descriptor
+```
+
+??? note "My output"
+    ```bash
+    ./hidapitester --vidpid 046D/C626 --open --get-report-descriptor
+    Opening device, vid/pid: 0x046D/0xC626
+    Report Descriptor:
+    05 01 09 08 A1 01 A1 00 85 01 16 A2 FE 26 5E 01 36 88 FA 46 78 05 55 0C 65 11 09 30 09 31 09 32
+    75 10 95 03 81 06 C0 A1 00 85 02 09 33 09 34 09 35 75 10 95 03 81 06 C0 A1 02 85 03 05 01 05 09
+    ...
+    Closing device
+    ```
 
 ### 3. Add Device to `devices.toml`
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@
 
 3Dconnexion Space Mouse in Python using raw HID.
 Note: you **don't** need to install or use any of the drivers or 3Dconnexion software to use this package.
-It interfaces with the controller directly with `hidapi` and python wrapper library `easyhid`.
+It interfaces with the controller directly with `hidapi`, via the [`hidapi`](https://pypi.org/project/hidapi/) Python bindings.
 
 <p align="center">
 <a href="https://hit.kubaandrysek.cz/?url=https%3A%2F%2Fgithub.com%2FJakubAndrysek%2Fpyspacemouse&chart=true"><img src="https://hit.kubaandrysek.cz/?url=https%3A%2F%2Fgithub.com%2FJakubAndrysek%2Fpyspacemouse"/></a>
@@ -241,11 +241,9 @@ See the [examples/](https://github.com/JakubAndrysek/PySpaceMouse/tree/master/ex
 
 ## Dependencies
 
-### hidapi (C library)
-
-- **Linux**: `sudo apt-get install libhidapi-dev`
-- **macOS**: `brew install hidapi`
-- **Windows**: Download from [hidapi releases](https://github.com/libusb/hidapi/releases)
+`pip install pyspacemouse` pulls in the [`hidapi`](https://pypi.org/project/hidapi/) package,
+whose wheels bundle the hidapi C library. There is nothing else to install on Linux, macOS
+or Windows.
 
 ### Linux permissions
 
@@ -253,12 +251,6 @@ See the [examples/](https://github.com/JakubAndrysek/PySpaceMouse/tree/master/ex
 echo 'KERNEL=="hidraw*", SUBSYSTEM=="hidraw", MODE="0664", GROUP="plugdev"' | sudo tee /etc/udev/rules.d/99-hidraw-permissions.rules
 sudo usermod -aG plugdev $USER
 newgrp plugdev
-```
-
-### macOS PATH
-
-```bash
-export DYLD_LIBRARY_PATH=/opt/homebrew/Cellar/hidapi/<VERSION>/lib:$DYLD_LIBRARY_PATH
 ```
 
 ## Troubleshooting

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,31 @@ It interfaces with the controller directly with `hidapi`, via the [`hidapi`](htt
 pip install pyspacemouse
 ```
 
+## CLI
+
+```bash
+pyspacemouse --list-connected    # Show connected devices
+pyspacemouse --list-supported    # Show all supported types
+pyspacemouse --list-hid          # Show all HID devices
+pyspacemouse --test              # Test connection
+pyspacemouse --version           # Show version
+```
+### Linux permissions
+
+On linux, you may not have permission to read from the device.
+To fix this, you can create a udev rule based on the device's Vendor ID (`256f` for 3Dconnexion's):
+
+```bash
+echo 'SUBSYSTEM=="hidraw", ATTRS{idVendor}=="256f", MODE="0660", TAG+="uaccess"' | sudo tee /etc/udev/rules.d/50-spacemouse.rules
+echo 'SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="256f", MODE="0660", TAG+="uaccess"' | sudo tee -a /etc/udev/rules.d/50-spacemouse.rules
+sudo udevadm control --reload-rules && sudo udevadm trigger
+```
+
+## Troubleshooting
+
+See [troubleshooting.md](./troubleshooting.md) for help with common issues.
+
+
 ## Quick Start
 
 Here we use `has_motion()` to check if any of the spatial axes have non-zero values.
@@ -212,15 +237,6 @@ with pyspacemouse.open(device_spec=custom) as device:
 
 See [Custom Device Configuration](./mouseApi/index.md#custom-device-configuration) for full API.
 
-## CLI
-
-```bash
-pyspacemouse --list-connected    # Show connected devices
-pyspacemouse --list-supported    # Show all supported types
-pyspacemouse --list-hid          # Show all HID devices
-pyspacemouse --test              # Test connection
-pyspacemouse --version           # Show version
-```
 
 ## Examples
 
@@ -244,20 +260,6 @@ See the [examples/](https://github.com/JakubAndrysek/PySpaceMouse/tree/master/ex
 `pip install pyspacemouse` pulls in the [`hidapi`](https://pypi.org/project/hidapi/) package,
 whose wheels bundle the hidapi C library. There is nothing else to install on Linux, macOS
 or Windows.
-
-### Linux permissions
-
-Use `lsusb` to find your device's vendor ID (`256f` is 3Dconnexion's):
-
-```bash
-echo 'SUBSYSTEM=="hidraw", ATTRS{idVendor}=="256f", MODE="0660", TAG+="uaccess"' | sudo tee /etc/udev/rules.d/50-spacemouse.rules
-echo 'SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="256f", MODE="0660", TAG+="uaccess"' | sudo tee -a /etc/udev/rules.d/50-spacemouse.rules
-sudo udevadm control --reload-rules && sudo udevadm trigger
-```
-
-## Troubleshooting
-
-See [troubleshooting.md](./troubleshooting.md) for help with common issues.
 
 ## Developing / Contributing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -247,10 +247,14 @@ or Windows.
 
 ### Linux permissions
 
+Use `lsusb` to find your device's vendor ID (`256f` is 3Dconnexion's):
+
 ```bash
-echo 'KERNEL=="hidraw*", SUBSYSTEM=="hidraw", MODE="0664", GROUP="plugdev"' | sudo tee /etc/udev/rules.d/99-hidraw-permissions.rules
-sudo usermod -aG plugdev $USER
-newgrp plugdev
+echo 'SUBSYSTEM=="hidraw", ATTRS{idVendor}=="256f", MODE="0664", GROUP="input", TAG+="uaccess"' | sudo tee /etc/udev/rules.d/99-spacemouse.rules
+echo 'SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTR{idVendor}=="256f", MODE="0664", GROUP="input", TAG+="uaccess"' | sudo tee -a /etc/udev/rules.d/99-spacemouse.rules
+sudo udevadm control --reload-rules && sudo udevadm trigger
+sudo usermod -aG input $USER
+newgrp input
 ```
 
 ## Troubleshooting

--- a/docs/README.md
+++ b/docs/README.md
@@ -250,11 +250,9 @@ or Windows.
 Use `lsusb` to find your device's vendor ID (`256f` is 3Dconnexion's):
 
 ```bash
-echo 'SUBSYSTEM=="hidraw", ATTRS{idVendor}=="256f", MODE="0664", GROUP="input", TAG+="uaccess"' | sudo tee /etc/udev/rules.d/99-spacemouse.rules
-echo 'SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTR{idVendor}=="256f", MODE="0664", GROUP="input", TAG+="uaccess"' | sudo tee -a /etc/udev/rules.d/99-spacemouse.rules
+echo 'SUBSYSTEM=="hidraw", ATTRS{idVendor}=="256f", MODE="0660", TAG+="uaccess"' | sudo tee /etc/udev/rules.d/50-spacemouse.rules
+echo 'SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="256f", MODE="0660", TAG+="uaccess"' | sudo tee -a /etc/udev/rules.d/50-spacemouse.rules
 sudo udevadm control --reload-rules && sudo udevadm trigger
-sudo usermod -aG input $USER
-newgrp input
 ```
 
 ## Troubleshooting

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -42,89 +42,58 @@ See [Custom Device Configuration](https://spacemouse.kubaandrysek.cz/mouseApi#cu
 
 ## Common issues
 
-### ModuleNotFoundError: No module named 'easyhid'
+### ModuleNotFoundError: No module named 'hid'
 
-- Install `easyhid` by `pip install easyhid`.
+- The [`hidapi`](https://pypi.org/project/hidapi/) package is missing. It is installed
+  automatically with `pyspacemouse`, so this usually means you are in a different
+  environment than you think. Install it with `pip install hidapi`.
 
-### AttributeError: function/symbol 'hid_enumerate' not found in library '<None>': python3: undefined symbol: hid_enumerate
+### ImportError: The `hid` module ... is not cython-hidapi
 
-- HID C library is not installed or not found in PATH.
-- Follow the instructions in [requirements](./README.md#dependencies).
+- The [`hid`](https://pypi.org/project/hid/) package (pyhidapi) is installed and is
+  shadowing the module `hidapi` provides. Both distributions install a top-level module
+  called `hid`, so only one of them can be imported at a time.
+- Remove the other one and reinstall:
 
-<hr>
+  ```bash
+  pip uninstall hid
+  pip install --force-reinstall hidapi
+  ```
 
-## Mac OS (M1)
-
-!!! info "External dependencies"
-    You don't have to install original 3Dconnexion driver `3DxWare 10`. This library works directly with `hidapi` device interface.
-
-If you are using a Mac with an M1 chip or newer, you may encounter issues when installing the dependencies.
-Required dependency is `hidapi` which you can install using Homebrew `brew install hidapi`.
-
-By default, the `hidapi` library is installed in `/opt/homebrew/Cellar/hidapi/<VERSION>/lib` directory, and you need to add it to your `DYLD_LIBRARY_PATH` environment variable.
-It is possible to add it to your `.bashrc` or `.zshrc` file, but you can also add it directly in the terminal (only for the current session).
-
-Replace `<VERSION>` with the version you have installed on your system (`brew info hidapi`).
-```bash
-export DYLD_LIBRARY_PATH=/opt/homebrew/Cellar/hidapi/<VERSION>/lib:$DYLD_LIBRARY_PATH
-```
-
-After this setup everything works correctly.
-Tested on:
-
-- MacBook Pro 14 (M1 Pro, 2021)
-- ... add your device and feedback
 
 <hr>
 
-## Testing Hidapi
+## Checking your device is visible
 
-If you are not sure if `hidapi` is installed correctly, you can test it with the console tool [hidapitester](https://github.com/todbot/hidapitester).
-This tool provides a simple interface to test the communication with HID devices.
-On GitHub, you can find the source code and precompiled binaries for Windows, Linux, and Mac OS.
+The hidapi C library ships inside the `hidapi` wheel, so there is nothing to install or
+verify. When something is wrong it is almost always the device or its permissions.
 
-Just download the binary for your system and run it in the terminal.
+The CLI goes through the same backend the library does, so trust it over external tools:
 
-List connected devices:
 ```bash
-./hidapitester --list
-```
-??? note "My output"
-    ```bash
-    046D/C626: 3Dconnexion - SpaceNavigator
-    045E/07A5: Microsoft - Microsoft 2.4GHz Transceiver v9.0
-    ...
-    ```
-Read data from the device (replace `<VID/PID>` with the VID/PID of your device):
-```bash
-./hidapitester --vidpid <VID/PID> --open --read-input
+pyspacemouse --list-hid         # every HID device the system exposes
+pyspacemouse --list-connected   # the ones recognised as SpaceMice
+pyspacemouse --test             # open the first one and print live axis values
 ```
 
 ??? note "My output"
     ```bash
-    ./hidapitester --vidpid 046D/C626 --open --read-input
-    Opening device, vid/pid: 0x046D/0xC626
-    Reading 64-byte input report 0, 250 msec timeout...read 7 bytes:
-    01 76 00 00 00 FA FF 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-    Closing device
+    $ pyspacemouse --list-connected
+    Connected SpaceMouse devices:
+      - SpaceMouseCompact (/dev/hidraw5)
     ```
 
-Read descriptor from the device (replace `<VID/PID>` with the VID/PID of your device):
-```bash
-./hidapitester --vidpid <VID/PID> --open --get-report-descriptor
-```
+Work down from the top:
 
-??? note "My output"
-    ```bash
-    ./hidapitester --vidpid 046D/C626 --open --get-report-descriptor
-    Opening device, vid/pid: 0x046D/0xC626
-    Report Descriptor:
-    05 01 09 08 A1 01 A1 00 85 01 16 A2 FE 26 5E 01 36 88 FA 46 78 05 55 0C 65 11 09 30 09 31 09 32
-    75 10 95 03 81 06 C0 A1 00 85 02 09 33 09 34 09 35 75 10 95 03 81 06 C0 A1 02 85 03 05 01 05 09
-    ...
-    Closing device
-    ```
+- **Nothing in `--list-hid`** - the OS isn't seeing the device at all. Check the cable, try
+  another port, and on a wireless model check the receiver.
+- **In `--list-hid` but not `--list-connected`** - the device is visible but its VID/PID
+  isn't in the device table. Compare against `pyspacemouse --list-supported`, then open an
+  issue with the IDs or supply your own `device_spec`.
+- **In `--list-connected` but `--test` won't open** - permissions; see the Linux section
+  below. If you have 3DxWare installed, try quitting it first.
+- **Opens, but the axes do nothing** - the device is being read but its report layout
+  doesn't match the spec. See [Adding a new device](./CONTRIBUTING.md#adding-a-new-device).
 
 <hr>
 
@@ -137,11 +106,17 @@ If you encounter an error like `Failed to open device` or `Permission denied` wh
 **Error example:**
 ```bash
 Traceback (most recent call last):
-  File "/home/user/.local/lib/python3.8/site-packages/pyspacemouse/pyspacemouse.py", line 183, in open
-    self.device.open()
-  File "/home/user/.local/lib/python3.8/site-packages/easyhid/easyhid.py", line 134, in open
-    raise HIDException("Failed to open device")
-easyhid.easyhid.HIDException: Failed to open device
+  File "/home/user/.local/lib/python3.12/site-packages/pyspacemouse/device.py", line 185, in open
+    device.open_path(self._hid_info["path"])
+  File "hidraw.pyx", line 158, in hidraw.device.open_path
+OSError: open failed
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/home/user/.local/lib/python3.12/site-packages/pyspacemouse/device.py", line 187, in open
+    raise RuntimeError("Failed to open device") from e
+RuntimeError: Failed to open device
 ```
 
 **Solution:**
@@ -191,61 +166,3 @@ easyhid.easyhid.HIDException: Failed to open device
 After these steps, your SpaceMouse should work correctly without permission errors.
 
 <hr>
-
-## Windows
-
-!!! info "Error message - OSError: cannot load library 'hidapi.dll'"
-    ```bash
-    Traceback (most recent call last):
-    File "C:\Users\Student\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.12_qbz5n2kfra8p0\LocalCache\local-packages\Python312\site-packages\easyhid\easyhid.py", line 53, in <module>
-        hidapi = ffi.dlopen('hidapi.dll')
-    File "C:\Users\Student\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.12_qbz5n2kfra8p0\LocalCache\local-packages\Python312\site-packages\cffi\api.py", line 150, in dlopen
-        lib, function_cache = _make_ffi_library(self, name, flags)
-    File "C:\Users\Student\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.12_qbz5n2kfra8p0\LocalCache\local-packages\Python312\site-packages\cffi\api.py", line 832, in _make_ffi_library
-        backendlib = _load_backend_lib(backend, libname, flags)
-    File "C:\Users\Student\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.12_qbz5n2kfra8p0\LocalCache\local-packages\Python312\site-packages\cffi\api.py", line 827, in _load_backend_lib
-        raise OSError(msg)
-    OSError: cannot load library 'hidapi.dll': error 0x7e.  Additionally, ctypes.util.find_library() did not manage to locate a library called 'hidapi.dll
-    ```
-
-??? info "Other error message - OSError: dlopen(None) cannot work on Windows for Python 3"
-    ```bash
-    File "C:\Users\Student\Downloads\basicExample.py", line 1, in <module>
-        import pyspacemouse
-    File "C:\Users\Student\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.12_qbz5n2kfra8p0\LocalCache\local-packages\Python312\site-packages\pyspacemouse\__init__.py", line 1, in <module>
-        from .pyspacemouse import *
-    File "C:\Users\Student\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.12_qbz5n2kfra8p0\LocalCache\local-packages\Python312\site-packages\pyspacemouse\pyspacemouse.py", line 1, in <module>
-        from easyhid import Enumeration, HIDException
-    File "C:\Users\Student\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.12_qbz5n2kfra8p0\LocalCache\local-packages\Python312\site-packages\easyhid\__init__.py", line 8, in <module>
-        from easyhid.easyhid import *
-    File "C:\Users\Student\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.12_qbz5n2kfra8p0\LocalCache\local-packages\Python312\site-packages\easyhid\easyhid.py", line 55, in <module>
-        hidapi = ffi.dlopen(ctypes.util.find_library('hidapi.dll'))
-    File "C:\Users\Student\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.12_qbz5n2kfra8p0\LocalCache\local-packages\Python312\site-packages\cffi\api.py", line 150, in dlopen
-        lib, function_cache = _make_ffi_library(self, name, flags)
-    File "C:\Users\Student\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.12_qbz5n2kfra8p0\LocalCache\local-packages\Python312\site-packages\cffi\api.py", line 832, in _make_ffi_library
-        backendlib = _load_backend_lib(backend, libname, flags)
-    File "C:\Users\Student\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.12_qbz5n2kfra8p0\LocalCache\local-packages\Python312\site-packages\cffi\api.py", line 821, in _load_backend_lib
-        raise OSError("dlopen(None) cannot work on Windows for Python 3 "
-    OSError: dlopen(None) cannot work on Windows for Python 3 (see http://bugs.python.org/issue23606)
-    ```
-
-
-If you are using Windows, you may encounter issues with the `hidapi` library.
-The library is not included in the system, so you have to install it manually.
-
-Go to [hidapi GitHub](https://github.com/libusb/hidapi/releases/latest) and download the latest version of the library in zip format.
-Extract the zip file and copy the x64/x86 folder with `hidapi.dll` to the static location where will be found by the system.
-
-To make it work, you have to add the folder to the system `PATH` variable.
-
-Go to Windows settings and search for `enviroment`.
-![image](https://github.com/JakubAndrysek/PySpaceMouse/assets/33494544/ce7ba2b3-8e40-48bb-8348-5a1f932146c3)
-
-Click on the `Environment variables`.
-![image](https://github.com/JakubAndrysek/PySpaceMouse/assets/33494544/ce22bae7-a0c8-4f19-9204-7f1a12f28782)
-
-Append the path to the folder with `hidapi.dll` to the `Path` variable.
-![image](https://github.com/JakubAndrysek/PySpaceMouse/assets/33494544/0ddefada-b595-49f3-bf0f-d11567cf887f)
-
-After this setup, you have to restart (maybe log out) your computer to apply the changes.
-Let's start using this library in your Python code.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -132,16 +132,18 @@ RuntimeError: Failed to open device
    Here, `256f` is the Vendor ID and `c652` is the Product ID.
 
 2. **Create udev rules to grant permissions:**
+   > Rules that use `TAG+="uaccess"` must have a priority number below `73` (e.g. `50-`) so they are evaluated before systemd seat rules.
+
    ```bash
    cd /etc/udev/rules.d
-   sudo touch 99-spacemouse.rules
-   sudo nano 99-spacemouse.rules
+   sudo touch 50-spacemouse.rules
+   sudo nano 50-spacemouse.rules
    ```
 
-3. **Add the following rules** (replace `046d` and `c62b` with your Vendor ID and Product ID):
-   ```bash
-   SUBSYSTEM=="hidraw", ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c62b", MODE="0664", GROUP="input", TAG+="uaccess"
-   SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTR{idVendor}=="046d", ATTR{idProduct}=="c62b", MODE="0664", GROUP="input", TAG+="uaccess"
+3. **Add the following rules:**
+   ```udev
+   SUBSYSTEM=="hidraw", ATTRS{idVendor}=="256f", MODE="0660", TAG+="uaccess"
+   SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="256f", MODE="0660", TAG+="uaccess"
    ```
 
    Common SpaceMouse IDs:
@@ -156,12 +158,16 @@ RuntimeError: Failed to open device
    sudo udevadm trigger
    ```
 
-5. **Add your user to the input group:**
-   ```bash
-   sudo usermod -a -G input $USER
-   ```
+5. **Disconnect and reconnect your SpaceMouse.**
 
-6. **Disconnect and reconnect your SpaceMouse**, then log out and log back in to Ubuntu (or restart your computer).
+   With `TAG+="uaccess"`, the active desktop user is granted dynamic access automatically without needing to join groups or log out.
+
+   *(Optional)* **For headless remote access:** If you need access when not logged in locally at the desktop, create and assign a dedicated `spacemouse` group:
+   ```bash
+   sudo groupadd -f spacemouse
+   sudo usermod -aG spacemouse $USER
+   ```
+   and add `GROUP="spacemouse"` to the udev rules above.
 
 After these steps, your SpaceMouse should work correctly without permission errors.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -122,52 +122,57 @@ RuntimeError: Failed to open device
 **Solution:**
 
 1. **Find your device's Vendor ID and Product ID:**
-   ```bash
-   lsusb
-   ```
-   Look for your SpaceMouse device. Example output:
-   ```
-   Bus 001 Device 013: ID 256f:c652 3Dconnexion Universal Receiver
-   ```
-   Here, `256f` is the Vendor ID and `c652` is the Product ID.
+
+    ```bash
+    lsusb
+    ```
+    Look for your SpaceMouse device. Example output:
+    ```
+    Bus 001 Device 013: ID 256f:c652 3Dconnexion Universal Receiver
+    ```
+    Here, `256f` is the Vendor ID and `c652` is the Product ID.
 
 2. **Create udev rules to grant permissions:**
-   > Rules that use `TAG+="uaccess"` must have a priority number below `73` (e.g. `50-`) so they are evaluated before systemd seat rules.
 
-   ```bash
-   cd /etc/udev/rules.d
-   sudo touch 50-spacemouse.rules
-   sudo nano 50-spacemouse.rules
-   ```
+    > Rules that use `TAG+="uaccess"` must have a priority number below `73` (e.g. `50-`) so they are evaluated before systemd seat rules.
+
+    ```bash
+    cd /etc/udev/rules.d
+    sudo touch 50-spacemouse.rules
+    sudo nano 50-spacemouse.rules
+    ```
 
 3. **Add the following rules:**
-   ```udev
-   SUBSYSTEM=="hidraw", ATTRS{idVendor}=="256f", MODE="0660", TAG+="uaccess"
-   SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="256f", MODE="0660", TAG+="uaccess"
-   ```
 
-   Common SpaceMouse IDs:
-   - SpaceMouse Compact: `256f:c635`
-   - SpaceMouse Wireless: `256f:c62e`
-   - 3Dconnexion Universal Receiver: `256f:c652`
-   - SpaceNavigator: `046d:c626`
+    ```udev
+    SUBSYSTEM=="hidraw", ATTRS{idVendor}=="256f", MODE="0660", TAG+="uaccess"
+    SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="256f", MODE="0660", TAG+="uaccess"
+    ```
+
+    Common SpaceMouse IDs:
+
+    - SpaceMouse Compact: `256f:c635`
+    - SpaceMouse Wireless: `256f:c62e`
+    - 3Dconnexion Universal Receiver: `256f:c652`
+    - SpaceNavigator: `046d:c626`
 
 4. **Reload udev rules:**
-   ```bash
-   sudo udevadm control --reload-rules
-   sudo udevadm trigger
-   ```
+
+    ```bash
+    sudo udevadm control --reload-rules
+    sudo udevadm trigger
+    ```
 
 5. **Disconnect and reconnect your SpaceMouse.**
 
-   With `TAG+="uaccess"`, the active desktop user is granted dynamic access automatically without needing to join groups or log out.
+    With `TAG+="uaccess"`, the active desktop user is granted dynamic access automatically without needing to join groups or log out.
 
-   *(Optional)* **For headless remote access:** If you need access when not logged in locally at the desktop, create and assign a dedicated `spacemouse` group:
-   ```bash
-   sudo groupadd -f spacemouse
-   sudo usermod -aG spacemouse $USER
-   ```
-   and add `GROUP="spacemouse"` to the udev rules above.
+    *(Optional)* **For headless remote access:** If you need access when not logged in locally at the desktop, create and assign a dedicated `spacemouse` group:
+    ```bash
+    sudo groupadd -f spacemouse
+    sudo usermod -aG spacemouse $USER
+    ```
+    and add `GROUP="spacemouse"` to the udev rules above.
 
 After these steps, your SpaceMouse should work correctly without permission errors.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -140,8 +140,8 @@ RuntimeError: Failed to open device
 
 3. **Add the following rules** (replace `046d` and `c62b` with your Vendor ID and Product ID):
    ```bash
-   SUBSYSTEM=="input", GROUP="input", MODE="0660"
-   KERNEL=="hidraw*", ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c62b", MODE="0666"
+   SUBSYSTEM=="hidraw", ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c62b", MODE="0664", GROUP="input", TAG+="uaccess"
+   SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTR{idVendor}=="046d", ATTR{idProduct}=="c62b", MODE="0664", GROUP="input", TAG+="uaccess"
    ```
 
    Common SpaceMouse IDs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
     "Operating System :: OS Independent",
     "Topic :: System :: Hardware :: Universal Serial Bus (USB) :: Human Interface Device (HID)",
 ]
-dependencies = ["easyhid", "tomli; python_version < '3.11'"]
+dependencies = ["hidapi>=0.14", "tomli; python_version < '3.11'"]
 
 [project.urls]
 Documentation = "https://spacemouse.kubaandrysek.cz"

--- a/pyspacemouse/_hid.py
+++ b/pyspacemouse/_hid.py
@@ -1,0 +1,80 @@
+"""hidapi binding selection.
+
+pyspacemouse talks to devices through the `hidapi` package (cython-hidapi),
+which compiles the hidapi C library into its wheels. That means there is no
+system library to install and no dynamic-linker search path to configure on any
+platform.
+
+On Linux the package ships two modules built against different backends:
+
+- ``hidraw`` - the kernel hidraw backend. Devices are reported as ``/dev/hidrawN``
+  paths and permissions are granted by the udev rules in the README.
+- ``hid`` - the libusb backend. Devices are reported as bus addresses and the
+  kernel driver has to be detached first.
+
+We prefer ``hidraw`` there so that device paths stay stable and the documented
+udev rules keep working. macOS and Windows wheels only ship ``hid``.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Any, Optional
+
+_INSTALL_HINT = (
+    "Install it with `pip install hidapi`. Note that `hidapi` (cython-hidapi) is "
+    "a different package from `hid` (pyhidapi) even though both provide a module "
+    "named `hid`; if `hid` is installed it will shadow this one and must be "
+    "uninstalled. See https://spacemouse.kubaandrysek.cz for details."
+)
+
+_module: Optional[Any] = None
+
+
+def get_hid() -> Any:
+    """Return the hidapi binding module, importing it on first use.
+
+    The import is deferred so that the hardware-free parts of pyspacemouse
+    (types, config helpers, device specs) stay usable without the binding.
+
+    Raises:
+        ImportError: If the `hidapi` package is missing, or if a different
+            package is providing the `hid` module name.
+    """
+    global _module
+    if _module is None:
+        _module = _import_hid()
+    return _module
+
+
+def _import_hid() -> Any:
+    module = None
+
+    if sys.platform.startswith("linux"):
+        try:
+            import hidraw
+
+            module = hidraw
+        except ImportError:
+            # Older cython-hidapi releases, and source builds configured with
+            # --with-libusb, only provide `hid`.
+            module = None
+
+    if module is None:
+        try:
+            import hid
+
+            module = hid
+        except ImportError as e:
+            raise ImportError(f"pyspacemouse requires the `hidapi` package. {_INSTALL_HINT}") from e
+
+    # cython-hidapi exposes the `device` class; pyhidapi exposes `Device` and no
+    # `device`, so this tells the two apart and gives a message that names the
+    # actual problem instead of failing later with an AttributeError.
+    if not hasattr(module, "device"):
+        raise ImportError(
+            f"The `hid` module at {getattr(module, '__file__', '<unknown>')} is not "
+            f"cython-hidapi. {_INSTALL_HINT}"
+        )
+
+    return module

--- a/pyspacemouse/_hid.py
+++ b/pyspacemouse/_hid.py
@@ -73,7 +73,7 @@ def _import_hid() -> Any:
     # actual problem instead of failing later with an AttributeError.
     if not hasattr(module, "device"):
         raise ImportError(
-            f"The `hid` module at {getattr(module, '__file__', '<unknown>')} is not "
+            f"The `hid` module at {getattr(module, '__file__', '<unknown>')} is not from "
             f"cython-hidapi. {_INSTALL_HINT}"
         )
 

--- a/pyspacemouse/api.py
+++ b/pyspacemouse/api.py
@@ -135,7 +135,7 @@ def _create_and_open_device(
 
 
 def open_by_path(
-    path: str | Path,
+    path: str | bytes | Path,
     callback: Optional[Callable[[SpaceMouseState], None]] = None,
     dof_callback: Optional[Callable[[SpaceMouseState], None]] = None,
     dof_callbacks: Optional[Sequence[DofCallback]] = None,
@@ -145,13 +145,21 @@ def open_by_path(
     device_spec: Optional[DeviceInfo] = None,
     axis_convention: Optional[AxisConvention] = None,
 ) -> SpaceMouseDevice:
-    """Open a SpaceMouse device by its filesystem path.
+    """Open a SpaceMouse device by its HID path.
 
     This is mutually exclusive with open() - use this when you know the
     exact device path, use open() for automatic device discovery.
 
+    Only Linux reports HID paths that are filesystem paths. macOS reports
+    opaque service IDs ("DevSrvsID:4296357093") and Windows reports device
+    interface paths ("\\\\?\\HID#VID_256F..."), so the value is matched against
+    hid.enumerate() as an opaque string first. Any path from
+    get_connected_devices_by_path() therefore works on every platform, while
+    on Linux symlinks and relative paths still resolve as before.
+
     Args:
-        path: Filesystem path to the HID device (e.g., "/dev/hidraw0")
+        path: HID path of the device, as reported by
+              get_connected_devices_by_path() (e.g., "/dev/hidraw0" on Linux)
         callback: Called on every state change
         dof_callback: Called on axis state changes
         dof_callbacks: List of per-axis callbacks
@@ -173,27 +181,34 @@ def open_by_path(
         SpaceMouseDevice instance (use as context manager for auto-cleanup)
 
     Raises:
-        FileNotFoundError: If the specified path does not exist
+        FileNotFoundError: If no connected HID device has that path
         ValueError: If the device at path is not a supported SpaceMouse
                     (unless device_spec is provided)
         ImportError: If the hidapi bindings are not installed.
     """
     hid = get_hid()
-    path = Path(path)
-
-    if not path.exists():
-        raise FileNotFoundError(f"Device path '{path}' does not exist.")
-
-    # Resolve path in case it's relative or a symlink
-    path = path.resolve()
-
-    # Find the HID device at this path
+    path = os.fsdecode(path) if isinstance(path, bytes) else str(path)
+    candidates = hid.enumerate()
     hid_info = None
 
-    for candidate in hid.enumerate():
-        if Path(os.fsdecode(candidate["path"])).resolve() == path:
+    # A HID path is an opaque string, so try an exact match first - that is the
+    # only thing that works on macOS and Windows.
+    for candidate in candidates:
+        if os.fsdecode(candidate["path"]) == path:
             hid_info = candidate
             break
+
+    # Otherwise fall back to filesystem resolution, so Linux callers can pass a
+    # symlink or a relative path to a /dev/hidrawN node.
+    if hid_info is None and Path(path).exists():
+        resolved = Path(path).resolve()
+        for candidate in candidates:
+            try:
+                if Path(os.fsdecode(candidate["path"])).resolve() == resolved:
+                    hid_info = candidate
+                    break
+            except Exception:
+                continue  # Not a path the filesystem can make sense of.
 
     if hid_info is None:
         raise FileNotFoundError(f"No HID device found at path '{path}'.")

--- a/pyspacemouse/api.py
+++ b/pyspacemouse/api.py
@@ -16,12 +16,12 @@ Usage:
 
 from __future__ import annotations
 
+import os
 import warnings
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Sequence, Tuple
 
-from easyhid import Enumeration
-
+from ._hid import get_hid
 from .callbacks import ButtonCallback, Config, DofCallback
 from .config_helpers import apply_axis_convention
 from .device import SpaceMouseDevice
@@ -37,21 +37,18 @@ def get_connected_devices() -> List[str]:
         Empty list if no supported devices are found.
 
     Raises:
-        RuntimeError: If HID API is not installed.
+        ImportError: If the hidapi bindings are not installed.
     """
-    try:
-        hid = Enumeration()
-    except AttributeError as e:
-        raise RuntimeError(
-            "HID API is probably not installed. See https://spacemouse.kubaandrysek.cz for details."
-        ) from e
-
+    hid = get_hid()
     device_specs = get_device_specs()
     devices = []
 
-    for hid_device in hid.find():
+    for hid_info in hid.enumerate():
         for name, spec in device_specs.items():
-            if hid_device.vendor_id == spec.vendor_id and hid_device.product_id == spec.product_id:
+            if (
+                hid_info["vendor_id"] == spec.vendor_id
+                and hid_info["product_id"] == spec.product_id
+            ):
                 devices.append(name)
 
     return devices
@@ -73,29 +70,24 @@ def get_all_hid_devices() -> List[Tuple[str, str, int, int]]:
         List of tuples: (product_string, manufacturer_string, vendor_id, product_id)
 
     Raises:
-        RuntimeError: If HID API is not installed.
+        ImportError: If the hidapi bindings are not installed.
     """
-    try:
-        hid = Enumeration()
-    except AttributeError as e:
-        raise RuntimeError(
-            "HID API is probably not installed. See https://spacemouse.kubaandrysek.cz for details."
-        ) from e
+    hid = get_hid()
 
     return [
         (
-            dev.product_string or "",
-            dev.manufacturer_string or "",
-            dev.vendor_id,
-            dev.product_id,
+            hid_info["product_string"] or "",
+            hid_info["manufacturer_string"] or "",
+            hid_info["vendor_id"],
+            hid_info["product_id"],
         )
-        for dev in hid.find()
+        for hid_info in hid.enumerate()
     ]
 
 
 def _create_and_open_device(
     spec: DeviceInfo,
-    hid_device,
+    hid_info,
     callback: Optional[Callable[[SpaceMouseState], None]] = None,
     dof_callback: Optional[Callable[[SpaceMouseState], None]] = None,
     dof_callbacks: Optional[Sequence[DofCallback]] = None,
@@ -130,7 +122,7 @@ def _create_and_open_device(
             )
         spec = apply_axis_convention(spec, axis_convention)
 
-    mouse = SpaceMouseDevice(info=spec, device=hid_device)
+    mouse = SpaceMouseDevice(info=spec, hid_info=hid_info, nonblocking=nonblocking)
     mouse.configure(
         callback=callback,
         dof_callback=dof_callback,
@@ -139,7 +131,6 @@ def _create_and_open_device(
         button_callbacks=button_callbacks,
     )
     mouse.open()
-    hid_device.set_nonblocking(nonblocking)
     return mouse
 
 
@@ -185,7 +176,9 @@ def open_by_path(
         FileNotFoundError: If the specified path does not exist
         ValueError: If the device at path is not a supported SpaceMouse
                     (unless device_spec is provided)
+        ImportError: If the hidapi bindings are not installed.
     """
+    hid = get_hid()
     path = Path(path)
 
     if not path.exists():
@@ -195,16 +188,14 @@ def open_by_path(
     path = path.resolve()
 
     # Find the HID device at this path
-    hid = Enumeration()
-    hid_device = None
+    hid_info = None
 
-    for dev in hid.device_list:
-        dev_path = Path(dev.path).resolve()
-        if dev_path == path:
-            hid_device = dev
+    for candidate in hid.enumerate():
+        if Path(os.fsdecode(candidate["path"])).resolve() == path:
+            hid_info = candidate
             break
 
-    if hid_device is None:
+    if hid_info is None:
         raise FileNotFoundError(f"No HID device found at path '{path}'.")
 
     # Use provided spec or find matching device specification
@@ -217,16 +208,16 @@ def open_by_path(
 
         for device_s in all_specs.values():
             if (
-                hid_device.vendor_id == device_s.vendor_id
-                and hid_device.product_id == device_s.product_id
+                hid_info["vendor_id"] == device_s.vendor_id
+                and hid_info["product_id"] == device_s.product_id
             ):
                 spec = device_s
                 break
 
         if spec is None:
             raise ValueError(
-                f"Device at '{path}' (VID={hid_device.vendor_id:#06x}, "
-                f"PID={hid_device.product_id:#06x}) is not a supported SpaceMouse. "
+                f"Device at '{path}' (VID={hid_info['vendor_id']:#06x}, "
+                f"PID={hid_info['product_id']:#06x}) is not a supported SpaceMouse. "
                 f"Use device_spec parameter for custom/unsupported devices."
             )
 
@@ -234,7 +225,7 @@ def open_by_path(
 
     return _create_and_open_device(
         spec=spec,
-        hid_device=hid_device,
+        hid_info=hid_info,
         callback=callback,
         dof_callback=dof_callback,
         dof_callbacks=dof_callbacks,
@@ -294,7 +285,9 @@ def open(
     Raises:
         RuntimeError: If no device is found
         ValueError: If the specified device name is not recognized
+        ImportError: If the hidapi bindings are not installed.
     """
+    hid = get_hid()
     device_specs = get_device_specs()
 
     # Auto-detect device if not specified
@@ -312,12 +305,11 @@ def open(
     spec = device_spec if is_custom_spec else device_specs[device]
 
     # Find matching HID devices
-    hid = Enumeration()
     found = []
 
-    for hid_dev in hid.find():
-        if hid_dev.vendor_id == spec.vendor_id and hid_dev.product_id == spec.product_id:
-            found.append(hid_dev)
+    for hid_info in hid.enumerate():
+        if hid_info["vendor_id"] == spec.vendor_id and hid_info["product_id"] == spec.product_id:
+            found.append(hid_info)
 
     if not found:
         raise RuntimeError(f"Device '{device}' not found.")
@@ -326,12 +318,11 @@ def open(
     if device_index >= len(found):
         device_index = 0
 
-    hid_dev = found[device_index]
     print(f"{device} found")
 
     return _create_and_open_device(
         spec=spec,
-        hid_device=hid_dev,
+        hid_info=found[device_index],
         callback=callback,
         dof_callback=dof_callback,
         dof_callbacks=dof_callbacks,
@@ -382,23 +373,20 @@ def get_connected_devices_by_path() -> Dict[str, str]:
         Dict of paths: device names (e.g., {"/dev/hidraw0": "SpaceMouse Pro"}).
 
     Raises:
-        RuntimeError: If HID API is not installed.
+        ImportError: If the hidapi bindings are not installed.
     """
-    try:
-        hid = Enumeration()
-    except AttributeError as e:
-        raise RuntimeError(
-            "HID API is probably not installed. See https://spacemouse.kubaandrysek.cz for details."
-        ) from e
-
+    hid = get_hid()
     device_specs = get_device_specs()
     devices_by_path = {}
 
-    # hid.find() is all connected HID devices,
+    # hid.enumerate() is all connected HID devices,
     # device_specs is all supported Spacemouse devices.
-    for hid_device in hid.find():
+    for hid_info in hid.enumerate():
         for name, spec in device_specs.items():
-            if hid_device.vendor_id == spec.vendor_id and hid_device.product_id == spec.product_id:
-                devices_by_path[hid_device.path] = name
+            if (
+                hid_info["vendor_id"] == spec.vendor_id
+                and hid_info["product_id"] == spec.product_id
+            ):
+                devices_by_path[os.fsdecode(hid_info["path"])] = name
 
     return devices_by_path

--- a/pyspacemouse/device.py
+++ b/pyspacemouse/device.py
@@ -184,7 +184,7 @@ class SpaceMouseDevice:
         try:
             device.open_path(self._hid_info["path"])
         except OSError as e:
-            raise RuntimeError("Failed to open device") from e
+            raise RuntimeError(f"Failed to open device: {self._hid_info['path']}") from e
 
         device.set_nonblocking(1 if self._nonblocking else 0)
         self._device = device

--- a/pyspacemouse/device.py
+++ b/pyspacemouse/device.py
@@ -13,15 +13,14 @@ Supports context manager protocol for safe resource cleanup:
 from __future__ import annotations
 
 import timeit
-from typing import TYPE_CHECKING, Callable, List, Optional, Sequence
+from typing import Any, Callable, Dict, List, Optional, Sequence
 
-from easyhid import HIDException
-
+from ._hid import get_hid
 from .callbacks import ButtonCallback, Config, DofCallback
 from .types import AXIS_NAMES, ButtonState, DeviceInfo, SpaceMouseState
 
-if TYPE_CHECKING:
-    from easyhid import Device as HIDDevice
+# One entry from hid.enumerate(): device metadata, not an open connection.
+HIDInfo = Dict[str, Any]
 
 # High-accuracy clock for timing
 high_acc_clock = timeit.default_timer
@@ -53,6 +52,7 @@ class SpaceMouseDevice:
 
     __slots__ = (
         "_info",
+        "_hid_info",
         "_device",
         "_state",
         "_last_axis_time",
@@ -68,15 +68,24 @@ class SpaceMouseDevice:
         "_serial_number",
     )
 
-    def __init__(self, info: DeviceInfo, device: Optional[HIDDevice] = None) -> None:
+    def __init__(
+        self,
+        info: DeviceInfo,
+        hid_info: Optional[HIDInfo] = None,
+        nonblocking: bool = True,
+    ) -> None:
         """Initialize the SpaceMouseDevice.
 
         Args:
             info: Device specification from loader
-            device: Optional HID device instance
+            hid_info: Optional HID device metadata (one entry from
+                      hid.enumerate()), used by open() to connect
+            nonblocking: If True, reads return immediately when no report is
+                         pending. Applied when the connection is opened.
         """
         self._info = info
-        self._device = device
+        self._hid_info = hid_info
+        self._device: Optional[Any] = None
 
         # Initialize state
         self._state = SpaceMouseState(buttons=ButtonState([0] * len(info.button_specs)))
@@ -88,7 +97,7 @@ class SpaceMouseDevice:
         self._dof_callbacks: Optional[Sequence[DofCallback]] = None
         self._button_callback: Optional[Callable[[SpaceMouseState, List[int]], None]] = None
         self._button_callbacks: Optional[Sequence[ButtonCallback]] = None
-        self._nonblocking = True
+        self._nonblocking = nonblocking
 
         # Connection details (populated on open)
         self._product_name: str = ""
@@ -167,21 +176,26 @@ class SpaceMouseDevice:
 
     def open(self) -> None:
         """Open the connection to the device."""
-        if self._device is None:
+        if self._hid_info is None:
             raise RuntimeError("No HID device assigned to this SpaceMouseDevice")
 
+        hid = get_hid()
+        device = hid.device()
         try:
-            self._device.open()
-        except HIDException as e:
+            device.open_path(self._hid_info["path"])
+        except OSError as e:
             raise RuntimeError("Failed to open device") from e
 
-        # Copy product details
-        self._product_name = self._device.product_string or ""
-        self._vendor_name = self._device.manufacturer_string or ""
-        self._version_number = str(self._device.release_number or "")
+        device.set_nonblocking(1 if self._nonblocking else 0)
+        self._device = device
+
+        # Copy product details.
+        self._product_name = self._hid_info.get("product_string") or ""
+        self._vendor_name = self._hid_info.get("manufacturer_string") or ""
+        self._version_number = str(self._hid_info.get("release_number") or "")
 
         # Convert serial number to hex
-        serial = self._device.serial_number or ""
+        serial = self._hid_info.get("serial_number") or ""
         self._serial_number = "".join(f"{ord(c):02X}" for c in serial)
 
     def close(self) -> None:

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -122,52 +122,57 @@ RuntimeError: Failed to open device
 **Solution:**
 
 1. **Find your device's Vendor ID and Product ID:**
-   ```bash
-   lsusb
-   ```
-   Look for your SpaceMouse device. Example output:
-   ```
-   Bus 001 Device 013: ID 256f:c652 3Dconnexion Universal Receiver
-   ```
-   Here, `256f` is the Vendor ID and `c652` is the Product ID.
+
+    ```bash
+    lsusb
+    ```
+    Look for your SpaceMouse device. Example output:
+    ```
+    Bus 001 Device 013: ID 256f:c652 3Dconnexion Universal Receiver
+    ```
+    Here, `256f` is the Vendor ID and `c652` is the Product ID.
 
 2. **Create udev rules to grant permissions:**
-   > Rules that use `TAG+="uaccess"` must have a priority number below `73` (e.g. `50-`) so they are evaluated before systemd seat rules.
 
-   ```bash
-   cd /etc/udev/rules.d
-   sudo touch 50-spacemouse.rules
-   sudo nano 50-spacemouse.rules
-   ```
+    > Rules that use `TAG+="uaccess"` must have a priority number below `73` (e.g. `50-`) so they are evaluated before systemd seat rules.
+
+    ```bash
+    cd /etc/udev/rules.d
+    sudo touch 50-spacemouse.rules
+    sudo nano 50-spacemouse.rules
+    ```
 
 3. **Add the following rules:**
-   ```udev
-   SUBSYSTEM=="hidraw", ATTRS{idVendor}=="256f", MODE="0660", TAG+="uaccess"
-   SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="256f", MODE="0660", TAG+="uaccess"
-   ```
 
-   Common SpaceMouse IDs:
-   - SpaceMouse Compact: `256f:c635`
-   - SpaceMouse Wireless: `256f:c62e`
-   - 3Dconnexion Universal Receiver: `256f:c652`
-   - SpaceNavigator: `046d:c626`
+    ```udev
+    SUBSYSTEM=="hidraw", ATTRS{idVendor}=="256f", MODE="0660", TAG+="uaccess"
+    SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="256f", MODE="0660", TAG+="uaccess"
+    ```
+
+    Common SpaceMouse IDs:
+
+    - SpaceMouse Compact: `256f:c635`
+    - SpaceMouse Wireless: `256f:c62e`
+    - 3Dconnexion Universal Receiver: `256f:c652`
+    - SpaceNavigator: `046d:c626`
 
 4. **Reload udev rules:**
-   ```bash
-   sudo udevadm control --reload-rules
-   sudo udevadm trigger
-   ```
+
+    ```bash
+    sudo udevadm control --reload-rules
+    sudo udevadm trigger
+    ```
 
 5. **Disconnect and reconnect your SpaceMouse.**
 
-   With `TAG+="uaccess"`, the active desktop user is granted dynamic access automatically without needing to join groups or log out.
+    With `TAG+="uaccess"`, the active desktop user is granted dynamic access automatically without needing to join groups or log out.
 
-   *(Optional)* **For headless remote access:** If you need access when not logged in locally at the desktop, create and assign a dedicated `spacemouse` group:
-   ```bash
-   sudo groupadd -f spacemouse
-   sudo usermod -aG spacemouse $USER
-   ```
-   and add `GROUP="spacemouse"` to the udev rules above.
+    *(Optional)* **For headless remote access:** If you need access when not logged in locally at the desktop, create and assign a dedicated `spacemouse` group:
+    ```bash
+    sudo groupadd -f spacemouse
+    sudo usermod -aG spacemouse $USER
+    ```
+    and add `GROUP="spacemouse"` to the udev rules above.
 
 After these steps, your SpaceMouse should work correctly without permission errors.
 

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -144,7 +144,7 @@ RuntimeError: Failed to open device
    ```udev
    SUBSYSTEM=="hidraw", ATTRS{idVendor}=="256f", MODE="0660", TAG+="uaccess"
    SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="256f", MODE="0660", TAG+="uaccess"
-    ```
+   ```
 
    Common SpaceMouse IDs:
    - SpaceMouse Compact: `256f:c635`

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -132,17 +132,19 @@ RuntimeError: Failed to open device
    Here, `256f` is the Vendor ID and `c652` is the Product ID.
 
 2. **Create udev rules to grant permissions:**
+   > Rules that use `TAG+="uaccess"` must have a priority number below `73` (e.g. `50-`) so they are evaluated before systemd seat rules.
+
    ```bash
    cd /etc/udev/rules.d
-   sudo touch 99-spacemouse.rules
-   sudo nano 99-spacemouse.rules
+   sudo touch 50-spacemouse.rules
+   sudo nano 50-spacemouse.rules
    ```
 
-3. **Add the following rules** (replace `046d` and `c62b` with your Vendor ID and Product ID):
-   ```bash
-   SUBSYSTEM=="hidraw", ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c62b", MODE="0664", GROUP="input", TAG+="uaccess"
-   SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTR{idVendor}=="046d", ATTR{idProduct}=="c62b", MODE="0664", GROUP="input", TAG+="uaccess"
-   ```
+3. **Add the following rules:**
+   ```udev
+   SUBSYSTEM=="hidraw", ATTRS{idVendor}=="256f", MODE="0660", TAG+="uaccess"
+   SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="256f", MODE="0660", TAG+="uaccess"
+    ```
 
    Common SpaceMouse IDs:
    - SpaceMouse Compact: `256f:c635`
@@ -156,12 +158,16 @@ RuntimeError: Failed to open device
    sudo udevadm trigger
    ```
 
-5. **Add your user to the input group:**
-   ```bash
-   sudo usermod -a -G input $USER
-   ```
+5. **Disconnect and reconnect your SpaceMouse.**
 
-6. **Disconnect and reconnect your SpaceMouse**, then log out and log back in to Ubuntu (or restart your computer).
+   With `TAG+="uaccess"`, the active desktop user is granted dynamic access automatically without needing to join groups or log out.
+
+   *(Optional)* **For headless remote access:** If you need access when not logged in locally at the desktop, create and assign a dedicated `spacemouse` group:
+   ```bash
+   sudo groupadd -f spacemouse
+   sudo usermod -aG spacemouse $USER
+   ```
+   and add `GROUP="spacemouse"` to the udev rules above.
 
 After these steps, your SpaceMouse should work correctly without permission errors.
 

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -140,8 +140,8 @@ RuntimeError: Failed to open device
 
 3. **Add the following rules** (replace `046d` and `c62b` with your Vendor ID and Product ID):
    ```bash
-   SUBSYSTEM=="input", GROUP="input", MODE="0660"
-   KERNEL=="hidraw*", ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c62b", MODE="0666"
+   SUBSYSTEM=="hidraw", ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c62b", MODE="0664", GROUP="input", TAG+="uaccess"
+   SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTR{idVendor}=="046d", ATTR{idProduct}=="c62b", MODE="0664", GROUP="input", TAG+="uaccess"
    ```
 
    Common SpaceMouse IDs:

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -10,7 +10,17 @@ The library applies some axis inversions to make values more intuitive:
 - **Y axis**: Inverted for common conventions
 - **Rotations**: pitch/roll inverted from HID spec
 
-If your application needs different conventions (e.g., ROS, OpenGL), use the `modify_device_info()` function:
+If your application needs a common coordinate convention, pass it when opening the device:
+
+```python
+import pyspacemouse
+from pyspacemouse import AxisConvention
+
+with pyspacemouse.open(axis_convention=AxisConvention.ROS) as device:
+    state = device.read()
+```
+
+For custom conventions, use `modify_device_info()` to remap or invert axes:
 
 ```python
 import pyspacemouse
@@ -18,10 +28,9 @@ import pyspacemouse
 specs = pyspacemouse.get_device_specs()
 base = specs["SpaceNavigator"]
 
-# Customize axes for your application
 custom = pyspacemouse.modify_device_info(
     base,
-    invert_axes=["y", "z", "roll", "yaw"],  # Axes to flip
+    remap_axes={"x": "y", "y": ("x", -1), "yaw": ("yaw", -1)},
 )
 
 with pyspacemouse.open(device_spec=custom) as device:
@@ -33,89 +42,58 @@ See [Custom Device Configuration](https://spacemouse.kubaandrysek.cz/mouseApi#cu
 
 ## Common issues
 
-### ModuleNotFoundError: No module named 'easyhid'
+### ModuleNotFoundError: No module named 'hid'
 
-- Install `easyhid` by `pip install easyhid`.
+- The [`hidapi`](https://pypi.org/project/hidapi/) package is missing. It is installed
+  automatically with `pyspacemouse`, so this usually means you are in a different
+  environment than you think. Install it with `pip install hidapi`.
 
-### AttributeError: function/symbol 'hid_enumerate' not found in library '<None>': python3: undefined symbol: hid_enumerate
+### ImportError: The `hid` module ... is not cython-hidapi
 
-- HID C library is not installed or not found in PATH.
-- Follow the instructions in [requirements](./README.md#dependencies).
+- The [`hid`](https://pypi.org/project/hid/) package (pyhidapi) is installed and is
+  shadowing the module `hidapi` provides. Both distributions install a top-level module
+  called `hid`, so only one of them can be imported at a time.
+- Remove the other one and reinstall:
 
-<hr>
+  ```bash
+  pip uninstall hid
+  pip install --force-reinstall hidapi
+  ```
 
-## Mac OS (M1)
-
-!!! info "External dependencies"
-    You don't have to install original 3Dconnexion driver `3DxWare 10`. This library works directly with `hidapi` device interface.
-
-If you are using a Mac with an M1 chip or newer, you may encounter issues when installing the dependencies.
-Required dependency is `hidapi` which you can install using Homebrew `brew install hidapi`.
-
-By default, the `hidapi` library is installed in `/opt/homebrew/Cellar/hidapi/<VERSION>/lib` directory, and you need to add it to your `DYLD_LIBRARY_PATH` environment variable.
-It is possible to add it to your `.bashrc` or `.zshrc` file, but you can also add it directly in the terminal (only for the current session).
-
-Replace `<VERSION>` with the version you have installed on your system (`brew info hidapi`).
-```bash
-export DYLD_LIBRARY_PATH=/opt/homebrew/Cellar/hidapi/<VERSION>/lib:$DYLD_LIBRARY_PATH
-```
-
-After this setup everything works correctly.
-Tested on:
-
-- MacBook Pro 14 (M1 Pro, 2021)
-- ... add your device and feedback
 
 <hr>
 
-## Testing Hidapi
+## Checking your device is visible
 
-If you are not sure if `hidapi` is installed correctly, you can test it with the console tool [hidapitester](https://github.com/todbot/hidapitester).
-This tool provides a simple interface to test the communication with HID devices.
-On GitHub, you can find the source code and precompiled binaries for Windows, Linux, and Mac OS.
+The hidapi C library ships inside the `hidapi` wheel, so there is nothing to install or
+verify. When something is wrong it is almost always the device or its permissions.
 
-Just download the binary for your system and run it in the terminal.
+The CLI goes through the same backend the library does, so trust it over external tools:
 
-List connected devices:
 ```bash
-./hidapitester --list
-```
-??? note "My output"
-    ```bash
-    046D/C626: 3Dconnexion - SpaceNavigator
-    045E/07A5: Microsoft - Microsoft 2.4GHz Transceiver v9.0
-    ...
-    ```
-Read data from the device (replace `<VID/PID>` with the VID/PID of your device):
-```bash
-./hidapitester --vidpid <VID/PID> --open --read-input
+pyspacemouse --list-hid         # every HID device the system exposes
+pyspacemouse --list-connected   # the ones recognised as SpaceMice
+pyspacemouse --test             # open the first one and print live axis values
 ```
 
 ??? note "My output"
     ```bash
-    ./hidapitester --vidpid 046D/C626 --open --read-input
-    Opening device, vid/pid: 0x046D/0xC626
-    Reading 64-byte input report 0, 250 msec timeout...read 7 bytes:
-    01 76 00 00 00 FA FF 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-    Closing device
+    $ pyspacemouse --list-connected
+    Connected SpaceMouse devices:
+      - SpaceMouseCompact (/dev/hidraw5)
     ```
 
-Read descriptor from the device (replace `<VID/PID>` with the VID/PID of your device):
-```bash
-./hidapitester --vidpid <VID/PID> --open --get-report-descriptor
-```
+Work down from the top:
 
-??? note "My output"
-    ```bash
-    ./hidapitester --vidpid 046D/C626 --open --get-report-descriptor
-    Opening device, vid/pid: 0x046D/0xC626
-    Report Descriptor:
-    05 01 09 08 A1 01 A1 00 85 01 16 A2 FE 26 5E 01 36 88 FA 46 78 05 55 0C 65 11 09 30 09 31 09 32
-    75 10 95 03 81 06 C0 A1 00 85 02 09 33 09 34 09 35 75 10 95 03 81 06 C0 A1 02 85 03 05 01 05 09
-    ...
-    Closing device
-    ```
+- **Nothing in `--list-hid`** - the OS isn't seeing the device at all. Check the cable, try
+  another port, and on a wireless model check the receiver.
+- **In `--list-hid` but not `--list-connected`** - the device is visible but its VID/PID
+  isn't in the device table. Compare against `pyspacemouse --list-supported`, then open an
+  issue with the IDs or supply your own `device_spec`.
+- **In `--list-connected` but `--test` won't open** - permissions; see the Linux section
+  below. If you have 3DxWare installed, try quitting it first.
+- **Opens, but the axes do nothing** - the device is being read but its report layout
+  doesn't match the spec. See [Adding a new device](./CONTRIBUTING.md#adding-a-new-device).
 
 <hr>
 
@@ -128,11 +106,17 @@ If you encounter an error like `Failed to open device` or `Permission denied` wh
 **Error example:**
 ```bash
 Traceback (most recent call last):
-  File "/home/user/.local/lib/python3.8/site-packages/pyspacemouse/pyspacemouse.py", line 183, in open
-    self.device.open()
-  File "/home/user/.local/lib/python3.8/site-packages/easyhid/easyhid.py", line 134, in open
-    raise HIDException("Failed to open device")
-easyhid.easyhid.HIDException: Failed to open device
+  File "/home/user/.local/lib/python3.12/site-packages/pyspacemouse/device.py", line 185, in open
+    device.open_path(self._hid_info["path"])
+  File "hidraw.pyx", line 158, in hidraw.device.open_path
+OSError: open failed
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/home/user/.local/lib/python3.12/site-packages/pyspacemouse/device.py", line 187, in open
+    raise RuntimeError("Failed to open device") from e
+RuntimeError: Failed to open device
 ```
 
 **Solution:**
@@ -182,61 +166,3 @@ easyhid.easyhid.HIDException: Failed to open device
 After these steps, your SpaceMouse should work correctly without permission errors.
 
 <hr>
-
-## Windows
-
-!!! info "Error message - OSError: cannot load library 'hidapi.dll'"
-    ```bash
-    Traceback (most recent call last):
-    File "C:\Users\Student\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.12_qbz5n2kfra8p0\LocalCache\local-packages\Python312\site-packages\easyhid\easyhid.py", line 53, in <module>
-        hidapi = ffi.dlopen('hidapi.dll')
-    File "C:\Users\Student\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.12_qbz5n2kfra8p0\LocalCache\local-packages\Python312\site-packages\cffi\api.py", line 150, in dlopen
-        lib, function_cache = _make_ffi_library(self, name, flags)
-    File "C:\Users\Student\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.12_qbz5n2kfra8p0\LocalCache\local-packages\Python312\site-packages\cffi\api.py", line 832, in _make_ffi_library
-        backendlib = _load_backend_lib(backend, libname, flags)
-    File "C:\Users\Student\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.12_qbz5n2kfra8p0\LocalCache\local-packages\Python312\site-packages\cffi\api.py", line 827, in _load_backend_lib
-        raise OSError(msg)
-    OSError: cannot load library 'hidapi.dll': error 0x7e.  Additionally, ctypes.util.find_library() did not manage to locate a library called 'hidapi.dll
-    ```
-
-??? info "Other error message - OSError: dlopen(None) cannot work on Windows for Python 3"
-    ```bash
-    File "C:\Users\Student\Downloads\basicExample.py", line 1, in <module>
-        import pyspacemouse
-    File "C:\Users\Student\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.12_qbz5n2kfra8p0\LocalCache\local-packages\Python312\site-packages\pyspacemouse\__init__.py", line 1, in <module>
-        from .pyspacemouse import *
-    File "C:\Users\Student\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.12_qbz5n2kfra8p0\LocalCache\local-packages\Python312\site-packages\pyspacemouse\pyspacemouse.py", line 1, in <module>
-        from easyhid import Enumeration, HIDException
-    File "C:\Users\Student\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.12_qbz5n2kfra8p0\LocalCache\local-packages\Python312\site-packages\easyhid\__init__.py", line 8, in <module>
-        from easyhid.easyhid import *
-    File "C:\Users\Student\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.12_qbz5n2kfra8p0\LocalCache\local-packages\Python312\site-packages\easyhid\easyhid.py", line 55, in <module>
-        hidapi = ffi.dlopen(ctypes.util.find_library('hidapi.dll'))
-    File "C:\Users\Student\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.12_qbz5n2kfra8p0\LocalCache\local-packages\Python312\site-packages\cffi\api.py", line 150, in dlopen
-        lib, function_cache = _make_ffi_library(self, name, flags)
-    File "C:\Users\Student\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.12_qbz5n2kfra8p0\LocalCache\local-packages\Python312\site-packages\cffi\api.py", line 832, in _make_ffi_library
-        backendlib = _load_backend_lib(backend, libname, flags)
-    File "C:\Users\Student\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.12_qbz5n2kfra8p0\LocalCache\local-packages\Python312\site-packages\cffi\api.py", line 821, in _load_backend_lib
-        raise OSError("dlopen(None) cannot work on Windows for Python 3 "
-    OSError: dlopen(None) cannot work on Windows for Python 3 (see http://bugs.python.org/issue23606)
-    ```
-
-
-If you are using Windows, you may encounter issues with the `hidapi` library.
-The library is not included in the system, so you have to install it manually.
-
-Go to [hidapi GitHub](https://github.com/libusb/hidapi/releases/latest) and download the latest version of the library in zip format.
-Extract the zip file and copy the x64/x86 folder with `hidapi.dll` to the static location where will be found by the system.
-
-To make it work, you have to add the folder to the system `PATH` variable.
-
-Go to Windows settings and search for `enviroment`.
-![image](https://github.com/JakubAndrysek/PySpaceMouse/assets/33494544/ce7ba2b3-8e40-48bb-8348-5a1f932146c3)
-
-Click on the `Environment variables`.
-![image](https://github.com/JakubAndrysek/PySpaceMouse/assets/33494544/ce22bae7-a0c8-4f19-9204-7f1a12f28782)
-
-Append the path to the folder with `hidapi.dll` to the `Path` variable.
-![image](https://github.com/JakubAndrysek/PySpaceMouse/assets/33494544/0ddefada-b595-49f3-bf0f-d11567cf887f)
-
-After this setup, you have to restart (maybe log out) your computer to apply the changes.
-Let's start using this library in your Python code.


### PR DESCRIPTION
An alternative to #55 , also addressing macOS compatibility. This PR also includes a fix for opening by path under macOS/Windows, which don't use filesystem paths for devices.

@peter-mitrano-ar

## Summary by Sourcery

Switch the HID integration to cython-hidapi and improve cross-platform device discovery, opening, and setup guidance.

Bug Fixes:
- Fix HID device opening by path across Linux, macOS, and Windows by supporting platform-specific opaque device identifiers while retaining Linux path resolution.

Enhancements:
- Replace easyhid with the cython-hidapi bindings and defer backend loading with clear diagnostics for missing or conflicting HID packages.
- Prefer the Linux hidraw backend and apply nonblocking configuration when opening devices.
- Document bundled HID dependencies, platform-independent setup, device visibility diagnostics, and updated Linux permissions.
- Document opening devices with common axis conventions and customize axis mappings for application-specific coordinate systems.

Build:
- Update the project dependency from easyhid to hidapi and remove CI steps that install system hidapi libraries.

Documentation:
- Update the README, troubleshooting guides, and contributor documentation for the new hidapi backend, CLI diagnostics, cross-platform paths, and udev permissions.